### PR TITLE
Added OS-level package python3-jsonpatch

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -42,6 +42,7 @@
           - libffi-devel
           - policycoreutils-python-utils
           - python3-jmespath
+          - python3-jsonpatch
           - python3-pyyaml
           - python3-pip
           - python3-devel


### PR DESCRIPTION
This PR adds the OS-level package 'python3-jsonpatch' to the list of RPM packages to be installed on the target KVM host.

Fixes: #14 