### PR TITLE
Proper detection of Markdown documents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 *.yml linguist-language=YAML
 *.j2 linguist-detectable=true
 *.j2 linguist-language=Jinja
+*.md linguist-detectable=true
+*.md linguist-language=Markdown


### PR DESCRIPTION
## Related issue(s)

Resolves #24 

## Description

This PR updates the repo's .gitattribute file to allow GH to detect Markdown documents properly.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
