### PR TITLE
Added OpenShift command line tooling autocompletion for bash

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -67,6 +67,7 @@
           - net-tools
           - httpd
           - fio
+          - bash-completion
         state: latest
 
 - name: install prerequisite Python packages

--- a/ansible/roles/ocp_install_clients/tasks/main.yml
+++ b/ansible/roles/ocp_install_clients/tasks/main.yml
@@ -49,6 +49,11 @@
         group: root
         mode: '0755'
         remote_src: yes
+
+    - name: install bash completion for OpenShift client
+      ansible.builtin.shell:
+        cmd: '/usr/local/bin/oc completion bash > /etc/bash_completion.d/oc'
+        creates: /etc/bash_completion.d/oc
   always:
     - name: delete temporary download directory
       ansible.builtin.file:


### PR DESCRIPTION
## Related issue(s)

Resolves #27

## Description

This PR adds installation of bash autocompletion scripts for OpenShift client tooling to the existing playbooks.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>