### PR TITLE
Changed handling of httpd service

### DIFF
--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -78,11 +78,10 @@
         regexp: ^Listen 80
         line: Listen 8080
 
-    - name: restart httpd service
+    - name: reload httpd service
       ansible.builtin.service:
         name: httpd.service
-        state: started
-        enabled: yes
+        state: reloaded
 
 - name: update /etc/hosts
   block:

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -98,6 +98,7 @@
         - /usr/local/bin/terraform
         - /usr/local/share/terraform/plugins/local/ibm-cloud/ibm
         - /usr/local/bin/helm
+        - /etc/bash_completion.d/oc
 
 - name: check if SSH configuration for user root exists
   ansible.builtin.stat:

--- a/ansible/roles/ocp_install_clients/tasks/main.yml
+++ b/ansible/roles/ocp_install_clients/tasks/main.yml
@@ -53,7 +53,6 @@
     - name: install bash completion for OpenShift client
       ansible.builtin.shell:
         cmd: '/usr/local/bin/oc completion bash > /etc/bash_completion.d/oc'
-        creates: /etc/bash_completion.d/oc
   always:
     - name: delete temporary download directory
       ansible.builtin.file:

--- a/ansible/roles/ocp_install_cluster_wrapup/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster_wrapup/tasks/main.yml
@@ -8,3 +8,8 @@
 
 - name: persist SSH configuration for easy access to cluster nodes
   ansible.builtin.include_tasks: '{{ role_path }}/tasks/persist_ssh_config.yml'
+
+- name: stop httpd service
+  ansible.builtin.service:
+    name: httpd.service
+    state: stopped


### PR DESCRIPTION
## Related issue(s)

Resolves #29 

## Description

This PR changes the way the playbooks handle the httpd service. While the service is required by the actual OCP installation (for caching RHCOS images locally) it's enablement state requires unchanged - if the httpd service is disabled at host reboot it will remain so.

After the OCP installation is finished the httpd service is stopped. 

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>