### PR TITLE
Downgraded helm unarchive task for compatibility with older Ansible v…

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -241,8 +241,9 @@
         extra_opts:
           - --transform
           - 's/^linux-{{ ansible_architecture }}//'
-        include:
-          - 'linux-{{ ansible_architecture }}/helm'
+        exclude:
+          - 'linux-{{ ansible_architecture }}/README.md'
+          - 'linux-{{ ansible_architecture }}/LICENSE'
   always:
     - name: delete temporary download directory
       ansible.builtin.file:


### PR DESCRIPTION
…ersions

## Related issue(s)

Resolves #33 

## Description

This PR 'downgrades' the helm bundle unarchive task to be compatible with older versions of Ansible.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>