### PR TITLE
Included go binary location in PATH variable

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -144,7 +144,7 @@
         chdir: '{{ temp_dir.path }}/terraform'
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: remove existing terraform binary from /usr/local/bin
       ansible.builtin.file:
@@ -186,7 +186,7 @@
         chdir: '{{ temp_dir.path }}/terraform-provider-ibm'
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: create global terraform plugin directory
       ansible.builtin.file:

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -22,7 +22,7 @@
         TAGS: 'libvirt'
         CC: 'gcc'
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: remove existing openshift-install binary from /usr/local/bin
       ansible.builtin.file:


### PR DESCRIPTION
## Related issue(s)

Resolves #38 

## Description

This PR contains a fix for the prerequisite binary builds using 'go'. The go executable is now included in the corresponding PATH variable.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
