### PR TITLE
Retain original nameserver settings, do not upgrade OS-level and Pyth…

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -12,7 +12,6 @@
         state: '{{ item }}'
       loop:
         - present
-        - latest
 
     - name: install required packages
       ansible.builtin.dnf:
@@ -57,6 +56,7 @@
           - python3-virtualenv
           - python3-libselinux
           - python3-libsemanage
+          - python3-dnf-plugin-versionlock
           - ipmitool
           - gcc
           - gcc-c++
@@ -68,7 +68,7 @@
           - httpd
           - fio
           - bash-completion
-        state: latest
+        state: present
 
 - name: install prerequisite Python packages
   ansible.builtin.pip:
@@ -82,7 +82,6 @@
     extra_args: --no-cache-dir
   loop:
     - present
-    - latest
 
 - name: install go compiler
   block:

--- a/ansible/roles/firewall/tasks/main.yml
+++ b/ansible/roles/firewall/tasks/main.yml
@@ -5,7 +5,7 @@
     - name: ensure firewalld package is present
       ansible.builtin.dnf:
         name: firewalld
-        state: latest
+        state: present
 
     - name: start firewalld service
       ansible.builtin.service:

--- a/ansible/roles/networking/files/dnsmasq.add-hosts.conf
+++ b/ansible/roles/networking/files/dnsmasq.add-hosts.conf
@@ -1,0 +1,1 @@
+addn-hosts=/etc/hosts

--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -2,6 +2,15 @@
 
 - name: configure NetworkManager
   block:
+    - name: create backup of /etc/resolv.conf file
+      ansible.builtin.copy:
+        src: /etc/resolv.conf
+        dest: /etc/resolv.conf.bkup
+        owner: root
+        group: root
+        mode: '0644'
+        remote_src: true
+
     - name: enable dnsmasq module
       ansible.builtin.copy:
         src: '{{ role_path }}/files/networkmanager.dns.conf'
@@ -19,19 +28,34 @@
         mode: '0644'
         create: true
 
-    - name: increase dnsmasq cache size
+    - name: configure various aspects of dnsmasq
       ansible.builtin.copy:
-        src: '{{ role_path }}/files/dnsmasq.cache.conf'
-        dest: /etc/NetworkManager/dnsmasq.d/cache.conf
+        src: '{{ role_path }}/files/{{ item.src }}'
+        dest: '/etc/NetworkManager/dnsmasq.d/{{ item.tgt }}'
         owner: root
         group: root
         mode: '0644'
+      loop:
+        - { 'src': 'dnsmasq.cache.conf', 'tgt': 'cache.conf' }
+        - { 'src': 'dnsmasq.add-hosts.conf', 'tgt': 'add-hosts.conf' }
 
     - name: reload NetworkManager configuration
       ansible.builtin.service:
         name: NetworkManager
         state: reloaded
         enabled: true
+
+    - name: slurp original of /etc/resolv.conf file from backup
+      ansible.builtin.slurp:
+        src: /etc/resolv.conf.bkup
+      register: original_etc_resolv_conf
+
+    - name: retain any nameserver settings from the original /etc/resolv.conf file
+      ansible.builtin.lineinfile:
+        path: /etc/resolv.conf
+        line: '{{ item }}'
+        insertafter: '^nameserver.*$'
+      loop: "{{ original_etc_resolv_conf['content'] | b64decode | trim | regex_findall('^nameserver.*$', multiline=true) }}"
 
 - name: configure haproxy
   block:
@@ -46,7 +70,7 @@
     - name: ensure haproxy package is present
       ansible.builtin.dnf:
         name: haproxy
-        state: latest
+        state: present
 
     - name: start haproxy service
       ansible.builtin.service:
@@ -70,7 +94,7 @@
     - name: ensure httpd package is present
       ansible.builtin.dnf:
         name: httpd
-        state: latest
+        state: present
 
     - name: bind httpd to port 8080
       ansible.builtin.lineinfile:

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -121,6 +121,28 @@
     - '{{ libvirt_marker }}'
     - '{{ host_marker }}'
 
+- name: clean up /etc/resolv.conf
+  block:
+    - name: check if /etc/resolv.conf backup file exists
+      ansible.builtin.stat:
+        path: /etc/resolv.conf.bkup
+      register: etc_resolv_conf_bkup_info
+
+    - name: restore original /etc/resolv.conf from backup file
+      ansible.builtin.copy:
+        src: /etc/resolv.conf.bkup
+        dest: /etc/resolv.conf
+        owner: root
+        group: root
+        mode: '0644'
+        remote_src: true
+      when: etc_resolv_conf_bkup_info.stat.exists
+
+    - name: remove /etc/resolv.conf backup file
+      ansible.builtin.file:
+        path: /etc/resolv.conf.bkup
+        state: absent
+
 - name: clean up libvirt hooks
   block:
     - name: remove 'qemu' libvirt hook


### PR DESCRIPTION
…on packages to latest version

## Related issue(s)

Resolves #40
Resolves #41 

## Description

This PR contains a number of fixes:
- retain existing nameserver settings from /etc/resolv.conf even with dnsmasq enabled
- do not update OS-level and Python packages to latest versions

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>