### PR TITLE
Add butane installation

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,6 @@
 parseable: true
 quiet: true
 skip_list:
-  - package-latest
   - command-instead-of-module
   - no-changed-when
   - meta-no-info

--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -6,3 +6,5 @@ terraform_version: 1.1.3
 terraform_ibm_provider_version: 1.38.0
 
 helm_version: 3.8.0
+
+butane_version: 0.14.0

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -255,3 +255,45 @@
         path: '{{ temp_dir.path }}'
         state: absent
       when: temp_dir.path is defined
+
+- name: compile and install butane
+  block:
+    - name: create temporary download directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: butane
+      register: temp_dir
+
+    - name: fetch butane source code
+      ansible.builtin.git:
+        repo: 'https://github.com/coreos/butane.git'
+        dest: '{{ temp_dir.path }}/butane'
+        version: 'v{{ butane_version }}'
+
+    - name: build butane binary
+      ansible.builtin.command:
+        cmd: './build'
+        chdir: '{{ temp_dir.path }}/butane'
+      environment:
+        GOPATH: '{{ temp_dir.path }}/go'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+
+    - name: remove existing butane binary from /usr/local/bin
+      ansible.builtin.file:
+        path: /usr/local/bin/butane
+        state: absent
+
+    - name: copy butane binary to /usr/local/bin
+      ansible.builtin.copy:
+        src: '{{ temp_dir.path }}/butane/bin/{{ ansible_architecture }}/butane'
+        dest: /usr/local/bin/butane
+        owner: root
+        group: root
+        mode: '0755'
+        remote_src: true
+  always:
+    - name: delete temporary download directory
+      ansible.builtin.file:
+        path: '{{ temp_dir.path }}'
+        state: absent
+      when: temp_dir.path is defined


### PR DESCRIPTION
## Related issue(s)

Resolves #43 

## Description

This PR adds installing 'butane' to the playbooks. butane is compiled from source code before installation.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>