### PR TITLE
Added sanity check for incompatible libvirt packages

### DIFF
--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -58,3 +58,24 @@
           "{{ total_memory_required }} MB of RAM available"
           "{{ ansible_processor_cores }} CPU cores available"
           "{{ min_required_disk_space | int | human_readable(unit='G') }} free disk space available at /var/lib/libvirt"
+
+- name: ensure KVM host isn't using incompatible OS-level packages
+  block:
+    - name: fetch RPM package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: ensure that compatible 'libvirt' packages are being used (if present)
+      ansible.builtin.assert:
+        that:
+          - '{{ ansible_facts.packages["libvirt"][0]["release"] is not startswith("37.1.module") }}'
+        fail_msg: |-
+          "The KVM host has an incompatible version of libvirt installed:"
+          "{{ ansible_facts.packages["libvirt"][0]["version"] }}.{{ ansible_facts.packages["libvirt"][0]["release"] }}"
+          "This will prevent OpenShift to install properly on your KVM host."
+          "See here for more information:
+          "https://github.com/digitalocean/go-libvirt/issues/87"
+          "https://bugzilla.redhat.com/show_bug.cgi?id=2038812"
+          "As a workaround you can downgrade all incompatible libvirt packages to an older version, e.g.:"
+          "'yum downgrade libvirt'"
+      when: "'libvirt' in ansible_facts.packages"


### PR DESCRIPTION
## Related issue(s)

Resolves #12 

## Description

This PR adds a sanity check that is run prior to installing OCP that ensure the correct version of libvirt to be present on the KVM host.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>