### PR TITLE
Twofold check for incompatible libvirt package

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: account for know prerequisite software package incompatibilities
+- name: account for known prerequisite software package incompatibilities
   block:
     - name: fetch RPM package facts
       ansible.builtin.package_facts:

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -1,8 +1,20 @@
 ---
 
-- name: install prerequisite software packages
+- name: account for know prerequisite software package incompatibilities
   block:
-    - name: install python3-dnf-plugin-versionlock package first
+    - name: fetch RPM package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    # see: https://bugzilla.redhat.com/show_bug.cgi?id=2038812
+    - name: automatically downgrade incompatible version of libvirt package
+      ansible.builtin.command:
+        cmd: 'yum downgrade -y libvirt'
+      when:
+        - "'libvirt' in ansible_facts.packages"
+        - ansible_facts.packages['libvirt'][0]['release'] is startswith('37.1.module')
+
+    - name: install python3-dnf-plugin-versionlock package
       ansible.builtin.dnf:
         name:
           - python3-dnf-plugin-versionlock
@@ -14,6 +26,8 @@
           - libvirt*6.0.0-37.1.* # see: https://bugzilla.redhat.com/show_bug.cgi?id=2038812
         state: excluded
 
+- name: install prerequisite software packages
+  block:
     - name: install and update required dnf modules and package groups
       ansible.builtin.dnf:
         name:

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -67,9 +67,14 @@
         manager: auto
 
     # see: https://bugzilla.redhat.com/show_bug.cgi?id=2038812
-    - name: downgrade incompatible version of libvirt package
-      ansible.builtin.command:
-        cmd: 'yum downgrade -y libvirt'
+    - name: ensure that the KVM host has a compatible version of libvirt installed
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.packages['libvirt'][0]['release'] is not startswith('37.1.module')
+        fail_msg: |-
+          "The KVM host has a version of libvirt installed that is known to be incompatible with OpenShift:"
+          "{{ ansible_facts.packages['libvirt'][0]['name'] }}-{{ ansible_facts.packages['libvirt'][0]['version'] }}-{{ ansible_facts.packages['libvirt'][0]['release'] }}"
+          "Follow these instructions in the troubleshooting guide to resolve the issue:"
+          "https://github.com/ibm-s390-cloud/ocp-kvm-ipi-automation/blob/main/docs/TROUBLESHOOTING.md#using-an-incompatible-libvirt-version"
       when:
         - "'libvirt' in ansible_facts.packages"
-        - ansible_facts.packages['libvirt'][0]['release'] is startswith('37.1.module')


### PR DESCRIPTION
## Related issue(s)

Resolves #12 

## Description

The PR revises the workaround for the known incompatible libvirt version.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>