### PR TITLE
Added automatic detection of appropriate openshift-install version

### DIFF
--- a/ansible/filter_plugins/FilterUtils.py
+++ b/ansible/filter_plugins/FilterUtils.py
@@ -13,6 +13,7 @@ class FilterModule(object):
             'get_resources': self.get_resources,
             'all': self.all,
             'cexmode': self.cexmode,
+            'parse_version': self.parse_version,
         }
 
     '''
@@ -97,3 +98,26 @@ class FilterModule(object):
             return ""
         except Exception:
             return ""
+
+    '''
+    Jinja2 filter that returns a dictionary containing the major, minor and micro
+    (patch-level) version information parsed from the given input.
+
+    Parameters:
+    - input: either a list of string values or a single string value
+    '''
+    def parse_version(self, input):
+        try:
+            from packaging.version import parse
+            if isinstance(input, list):
+                parsed_version = parse(input[0])
+            else:
+                parsed_version = parse(input)
+            out = {
+              "major": parsed_version.major,
+              "minor": parsed_version.minor,
+              "micro": parsed_version.micro,
+            }
+            return out
+        except Exception:
+            return None

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: determine version of openshift-install to use
-  block:
-
-
-
 - name: build openshift-install binary
   block:
     - name: create temporary checkout directory

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: determine version of openshift-install to use
+  block:
+
+
+
 - name: build openshift-install binary
   block:
     - name: create temporary checkout directory
@@ -7,6 +12,30 @@
         state: directory
         suffix: ocpinst
       register: temp_dir
+
+    - name: download OpenShift release.txt file
+      ansible.builtin.get_url:
+        url: '{{ openshift_release_url }}'
+        dest: '{{ temp_dir.path }}/release.txt'
+        mode: '0440'
+        timeout: 120
+
+    - name: slurp OpenShift release.txt file
+      ansible.builtin.slurp:
+        src: '{{ temp_dir.path }}/release.txt'
+      register: ocp_release_txt
+
+    - name: determine version number of OpenShift release about to be installed
+      ansible.builtin.set_fact:
+        ocp_release_ver: "{{ ocp_release_txt['content'] | b64decode | trim | regex_search('^Name:[\\s]*([\\d.]*)$', '\\1', multiline=true) | parse_version }}"
+
+    - name: set openshift-install release version
+      ansible.builtin.set_fact:
+        openshift_installer_version: 'release-{{ ocp_release_ver.major }}.{{ ocp_release_ver.minor }}'
+      when:
+        - ocp_release_ver is defined
+        - ocp_release_ver.major is defined
+        - ocp_release_ver.minor is defined
 
     - name: fetch openshift-install source code
       ansible.builtin.git:


### PR DESCRIPTION
## Related issue(s)

Resolves #50 

## Description

This PR introduces automatic detection of the OpenShift installer version that is to be used for installing the given OCP release. If the appropriate OpenShift installer version cannot be detected, it falls back to the default 'release-4.9'.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
