### PR TITLE
Prevent overwrite of /etc/resolv.conf backup file

### DIFF
--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -9,7 +9,9 @@
         owner: root
         group: root
         mode: '0644'
+        attributes: '+i'
         remote_src: true
+        force: false
 
     - name: enable dnsmasq module
       ansible.builtin.copy:

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -136,6 +136,7 @@
         owner: root
         group: root
         mode: '0644'
+        attributes: '-i'
         remote_src: true
       when: etc_resolv_conf_bkup_info.stat.exists
 


### PR DESCRIPTION
## Related issue(s)

Resolves #53 

## Description

This PR implements changes to prevent the /etc/resolv.conf file from accidentally being overwritten.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>