### PR TITLE
Support for multiple server architectures: s390x, ppc64le, x86_64

### DIFF
--- a/ansible/check_ocp_cluster_state.yml
+++ b/ansible/check_ocp_cluster_state.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   tasks:
     - name: check the operational state of the OpenShift cluster

--- a/ansible/cleanup_ocp_install.yml
+++ b/ansible/cleanup_ocp_install.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   roles:
     - role: sanity_check

--- a/ansible/enable_crypto_resources.yml
+++ b/ansible/enable_crypto_resources.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
+- hosts: s390x_kvm_host
 
   roles:
     - role: sanity_check

--- a/ansible/enable_crypto_resources.yml
+++ b/ansible/enable_crypto_resources.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   roles:
     - role: sanity_check

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,6 +2,8 @@
 
 # settings for all Ansible hosts
 
+# Ansible-specific settings
+
 ansible_python_interpreter: '/usr/bin/python3'
 
 ansible_ssh_common_args: >
@@ -9,3 +11,27 @@ ansible_ssh_common_args: >
   -o BatchMode=yes
   -o UserKnownHostsFile=/dev/null
   -o StrictHostKeyChecking=no
+
+ansible_user: root
+
+# OpenShift-specific default settings
+
+openshift_installer_workdir: /root/ocp4-workdir
+
+machine_network_prefix: 192.168.126
+machine_network_master_range: 10
+machine_network_worker_range: 50
+
+cluster_network: '10.128.0.0/14'
+cluster_network_hostprefix: 23
+
+service_networks:
+  - 172.30.0.0/16
+
+openshift_setup_dedicated_infra_nodes: false
+openshift_number_of_infra_nodes: 2
+openshift_infra_root_volume_size: 68719476736
+openshift_infra_number_of_cpus: 4
+openshift_infra_memory_size: 16384
+
+cluster_waiting_period: 600

--- a/ansible/group_vars/ppc64le_kvm_host.yml
+++ b/ansible/group_vars/ppc64le_kvm_host.yml
@@ -2,28 +2,4 @@
 
 # default settings that apply to all ppc64le_kvm_host hosts
 
-ansible_user: root
-
 architecture_alias: ppc64le
-
-go_version: 1.17.6
-
-openshift_installer_workdir: /root/ocp4-workdir
-
-machine_network_prefix: 192.168.126
-machine_network_master_range: 10
-machine_network_worker_range: 50
-
-cluster_network: '10.128.0.0/14'
-cluster_network_hostprefix: 23
-
-service_networks:
-  - 172.30.0.0/16
-
-openshift_setup_dedicated_infra_nodes: false
-openshift_number_of_infra_nodes: 2
-openshift_infra_root_volume_size: 68719476736
-openshift_infra_number_of_cpus: 4
-openshift_infra_memory_size: 16384
-
-cluster_waiting_period: 600

--- a/ansible/group_vars/ppc64le_kvm_host.yml
+++ b/ansible/group_vars/ppc64le_kvm_host.yml
@@ -1,10 +1,10 @@
 ---
 
-# default settings that apply to all s390x_kvm_host hosts
+# default settings that apply to all ppc64le_kvm_host hosts
 
 ansible_user: root
 
-architecture_alias: s390x
+architecture_alias: ppc64le
 
 go_version: 1.17.6
 

--- a/ansible/group_vars/s390x_kvm_host.yml
+++ b/ansible/group_vars/s390x_kvm_host.yml
@@ -2,28 +2,4 @@
 
 # default settings that apply to all s390x_kvm_host hosts
 
-ansible_user: root
-
 architecture_alias: s390x
-
-go_version: 1.17.6
-
-openshift_installer_workdir: /root/ocp4-workdir
-
-machine_network_prefix: 192.168.126
-machine_network_master_range: 10
-machine_network_worker_range: 50
-
-cluster_network: '10.128.0.0/14'
-cluster_network_hostprefix: 23
-
-service_networks:
-  - 172.30.0.0/16
-
-openshift_setup_dedicated_infra_nodes: false
-openshift_number_of_infra_nodes: 2
-openshift_infra_root_volume_size: 68719476736
-openshift_infra_number_of_cpus: 4
-openshift_infra_memory_size: 16384
-
-cluster_waiting_period: 600

--- a/ansible/group_vars/x86_64_kvm_host.yml
+++ b/ansible/group_vars/x86_64_kvm_host.yml
@@ -2,28 +2,4 @@
 
 # default settings that apply to all x86_64_kvm_host hosts
 
-ansible_user: root
-
 architecture_alias: amd64
-
-go_version: 1.17.6
-
-openshift_installer_workdir: /root/ocp4-workdir
-
-machine_network_prefix: 192.168.126
-machine_network_master_range: 10
-machine_network_worker_range: 50
-
-cluster_network: '10.128.0.0/14'
-cluster_network_hostprefix: 23
-
-service_networks:
-  - 172.30.0.0/16
-
-openshift_setup_dedicated_infra_nodes: false
-openshift_number_of_infra_nodes: 2
-openshift_infra_root_volume_size: 68719476736
-openshift_infra_number_of_cpus: 4
-openshift_infra_memory_size: 16384
-
-cluster_waiting_period: 600

--- a/ansible/group_vars/x86_64_kvm_host.yml
+++ b/ansible/group_vars/x86_64_kvm_host.yml
@@ -1,10 +1,10 @@
 ---
 
-# default settings that apply to all s390x_kvm_host hosts
+# default settings that apply to all x86_64_kvm_host hosts
 
 ansible_user: root
 
-architecture_alias: s390x
+architecture_alias: amd64
 
 go_version: 1.17.6
 

--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -25,8 +25,8 @@ openshift_worker_root_volume_size: 137438953472   # in bytes
 openshift_worker_number_of_cpus: 16
 openshift_worker_memory_size: 32768               # in mebibytes (recommended **minimum** value)
 
-openshift_release_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/stable-4.9/release.txt'
-openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-{{ architecture_alias }}-qemu.{{ architecture_alias }}.qcow2.gz'
+openshift_release_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/stable-4.9/release.txt'
+openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-{{ ansible_architecture }}-qemu.{{ ansible_architecture }}.qcow2.gz'
 
 #############################################
 # <-- mandatory variables that need to be set
@@ -40,8 +40,8 @@ openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ arc
 openshift_client_version: 'stable-4.9'
 
 # the download source location of the OpenShift client tools packages
-oc_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
-opm_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
+oc_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
+opm_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
 
 # whether to install and setup vbmc and ipmi (usually only needed if you intend to use 'ocs-ci' with your OpenShift cluster)
 setup_vbmc_ipmi: false

--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -34,6 +34,7 @@ openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ans
 
 #############################################
 # --> optional variables that don't necessarily to be set
+# (these apply to all support server architectures)
 #############################################
 
 # the version of the OpenShift client tools to be installed on the KVM host
@@ -81,6 +82,16 @@ service_networks:
 # (see also: https://docs.openshift.com/container-platform/4.9/machine_management/creating-infrastructure-machinesets.html)
 openshift_setup_dedicated_infra_nodes: false
 
+#############################################
+# <-- optional variables that don't necessarily to be set
+# (these apply to all support server architectures)
+#############################################
+
+#############################################
+# --> optional variables that don't necessarily to be set
+# (these apply only to *s390x* server architecture)
+#############################################
+
 # a list of crypto resources present on the host that are to be exposed
 # to the OpenShift cluster worker nodes (using the k8s CEX device plugin)
 # (see also: https://github.com/ibm-s390-cloud/k8s-cex-dev-plugin)
@@ -97,4 +108,5 @@ crypto_config_set_project: kvm-ipi-automation
 
 #############################################
 # <-- optional variables that don't necessarily to be set
+# (these apply only to *s390x* server architecture)
 #############################################

--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -25,8 +25,8 @@ openshift_worker_root_volume_size: 137438953472   # in bytes
 openshift_worker_number_of_cpus: 16
 openshift_worker_memory_size: 32768               # in mebibytes (recommended **minimum** value)
 
-openshift_release_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/stable-4.9/release.txt'
-openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-s390x-qemu.s390x.qcow2.gz'
+openshift_release_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/stable-4.9/release.txt'
+openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-{{ architecture_alias }}-qemu.{{ architecture_alias }}.qcow2.gz'
 
 #############################################
 # <-- mandatory variables that need to be set
@@ -40,8 +40,8 @@ openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/
 openshift_client_version: 'stable-4.9'
 
 # the download source location of the OpenShift client tools packages
-oc_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
-opm_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
+oc_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
+opm_package_binary_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
 
 # whether to install and setup vbmc and ipmi (usually only needed if you intend to use 'ocs-ci' with your OpenShift cluster)
 setup_vbmc_ipmi: false

--- a/ansible/inventory.template
+++ b/ansible/inventory.template
@@ -3,3 +3,9 @@ all:
     s390x_kvm_host:
       hosts:
         $$YOUR_KVM_HOST_NAME$$:    # must match the name of the YAML file in subdirectory host_vars/
+    ppc64le_kvm_host:
+      hosts:
+        $$YOUR_KVM_HOST_NAME$$:    # must match the name of the YAML file in subdirectory host_vars/
+    x86_64_kvm_host:
+      hosts:
+        $$YOUR_KVM_HOST_NAME$$:    # must match the name of the YAML file in subdirectory host_vars/

--- a/ansible/prepare_ocp_install.yml
+++ b/ansible/prepare_ocp_install.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   roles:
     - role: sanity_check

--- a/ansible/reboot_host.yml
+++ b/ansible/reboot_host.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   tasks:
     - name: reboot host

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -189,7 +189,7 @@
 
     - name: create global terraform plugin directory
       ansible.builtin.file:
-        path: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ ansible_architecture }}'
+        path: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ architecture_alias }}'
         owner: root
         group: root
         mode: '0775'
@@ -197,13 +197,13 @@
 
     - name: remove existing terraform-provider-ibm binary if present
       ansible.builtin.file:
-        path: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ ansible_architecture }}/terraform-provider-ibm'
+        path: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ architecture_alias }}/terraform-provider-ibm'
         state: absent
 
     - name: copy terraform-provider-ibm binary to global terraform plugin directory
       ansible.builtin.copy:
         src: '{{ temp_dir.path }}/terraform-provider-ibm/terraform-provider-ibm'
-        dest: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ ansible_architecture }}/terraform-provider-ibm'
+        dest: '/usr/local/share/terraform/plugins/local/ibm-cloud/ibm/{{ terraform_ibm_provider_version }}/linux_{{ architecture_alias }}/terraform-provider-ibm'
         owner: root
         group: root
         mode: '0755'

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -94,8 +94,8 @@
 
     - name: download go tarball
       ansible.builtin.get_url:
-        url: 'https://dl.google.com/go/go{{ go_version }}.linux-{{ ansible_architecture }}.tar.gz'
-        dest: '{{ temp_dir.path }}/go{{ go_version }}.linux-{{ ansible_architecture }}.tar.gz'
+        url: 'https://dl.google.com/go/go{{ go_version }}.linux-{{ architecture_alias }}.tar.gz'
+        dest: '{{ temp_dir.path }}/go{{ go_version }}.tar.gz'
         mode: '0440'
         timeout: 120
 
@@ -106,7 +106,7 @@
 
     - name: install go
       ansible.builtin.unarchive:
-        src: '{{ temp_dir.path }}/go{{ go_version }}.linux-{{ ansible_architecture }}.tar.gz'
+        src: '{{ temp_dir.path }}/go{{ go_version }}.tar.gz'
         dest: /usr/local
         remote_src: true
 
@@ -220,8 +220,8 @@
 
     - name: download helm tarball
       ansible.builtin.get_url:
-        url: 'https://get.helm.sh/helm-v{{ helm_version }}-linux-{{ ansible_architecture }}.tar.gz'
-        dest: '{{ temp_dir.path }}/helm-v{{ helm_version }}-linux-{{ ansible_architecture }}.tar.gz'
+        url: 'https://get.helm.sh/helm-v{{ helm_version }}-linux-{{ architecture_alias }}.tar.gz'
+        dest: '{{ temp_dir.path }}/helm-v{{ helm_version }}.tar.gz'
         mode: '0440'
         timeout: 120
 
@@ -232,7 +232,7 @@
 
     - name: copy helm binary to /usr/local/bin
       ansible.builtin.unarchive:
-        src: '{{ temp_dir.path }}/helm-v{{ helm_version }}-linux-{{ ansible_architecture }}.tar.gz'
+        src: '{{ temp_dir.path }}/helm-v{{ helm_version }}.tar.gz'
         dest: /usr/local/bin
         remote_src: true
         owner: root
@@ -240,10 +240,10 @@
         mode: '0755'
         extra_opts:
           - --transform
-          - 's/^linux-{{ ansible_architecture }}//'
+          - 's/^linux-{{ architecture_alias }}//'
         exclude:
-          - 'linux-{{ ansible_architecture }}/README.md'
-          - 'linux-{{ ansible_architecture }}/LICENSE'
+          - 'linux-{{ architecture_alias }}/README.md'
+          - 'linux-{{ architecture_alias }}/LICENSE'
   always:
     - name: delete temporary download directory
       ansible.builtin.file:

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -285,7 +285,7 @@
 
     - name: copy butane binary to /usr/local/bin
       ansible.builtin.copy:
-        src: '{{ temp_dir.path }}/butane/bin/{{ ansible_architecture }}/butane'
+        src: '{{ temp_dir.path }}/butane/bin/{{ architecture_alias }}/butane'
         dest: /usr/local/bin/butane
         owner: root
         group: root

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -144,7 +144,7 @@
         chdir: '{{ temp_dir.path }}/terraform'
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: remove existing terraform binary from /usr/local/bin
       ansible.builtin.file:
@@ -186,7 +186,7 @@
         chdir: '{{ temp_dir.path }}/terraform-provider-ibm'
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: create global terraform plugin directory
       ansible.builtin.file:

--- a/ansible/roles/crypto/tasks/sanity_checks.yml
+++ b/ansible/roles/crypto/tasks/sanity_checks.yml
@@ -1,8 +1,10 @@
 ---
 
-- name: only continue if there are actually any crypto resources configured
+- name: only continue if the targeted KVM host architecture is s390x and there are actually any crypto resources configured
   ansible.builtin.assert:
-    that: crypto_adapters is defined
+    that:
+      - "ansible_architecture == 's390x'"
+      - crypto_adapters is defined
 
 - name: only continue if the number of workers assigned to crypto resources does not exceed the overall number of workers configured
   block:

--- a/ansible/roles/firewall/tasks/main.yml
+++ b/ansible/roles/firewall/tasks/main.yml
@@ -12,6 +12,7 @@
         name: firewalld
         state: started
         enabled: true
+        masked: false
 
     - name: add libvirt rich-rule
       ansible.posix.firewalld:

--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -2,6 +2,10 @@
 
 - name: configure NetworkManager
   block:
+    - name: remove immutability attribute from /etc/resolv.conf file
+      ansible.builtin.command:
+        cmd: 'chattr -i /etc/resolv.conf'
+
     - name: create backup of /etc/resolv.conf file
       ansible.builtin.copy:
         src: /etc/resolv.conf
@@ -60,6 +64,10 @@
         line: '{{ item }}'
         insertafter: '^nameserver.*$'
       loop: "{{ original_etc_resolv_conf['content'] | b64decode | trim | regex_findall('^nameserver.*$', multiline=true) }}"
+  always:
+    - name: add immutability attribute to /etc/resolv.conf file
+      ansible.builtin.command:
+        cmd: 'chattr +i /etc/resolv.conf'
 
 - name: configure haproxy
   block:

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -22,7 +22,7 @@
         TAGS: 'libvirt'
         CC: 'gcc'
         GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:{{ temp_dir.path }}/go/bin'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
 
     - name: remove existing openshift-install binary from /usr/local/bin
       ansible.builtin.file:

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -124,6 +124,10 @@
 
 - name: clean up /etc/resolv.conf
   block:
+    - name: remove immutability attribute from /etc/resolv.conf file
+      ansible.builtin.command:
+        cmd: 'chattr -i /etc/resolv.conf'
+
     - name: check if /etc/resolv.conf backup file exists
       ansible.builtin.stat:
         path: /etc/resolv.conf.bkup
@@ -136,7 +140,6 @@
         owner: root
         group: root
         mode: '0644'
-        attributes: '-i'
         remote_src: true
       when: etc_resolv_conf_bkup_info.stat.exists
 
@@ -148,6 +151,10 @@
       loop:
         - touch
         - absent
+  always:
+    - name: add immutability attribute to /etc/resolv.conf file
+      ansible.builtin.command:
+        cmd: 'chattr +i /etc/resolv.conf'
 
 - name: clean up libvirt hooks
   block:

--- a/ansible/roles/ocp_install_clients/tasks/main.yml
+++ b/ansible/roles/ocp_install_clients/tasks/main.yml
@@ -10,8 +10,8 @@
 
     - name: set default OpenShift and OPM client tarball download location variables
       ansible.builtin.set_fact:
-        oc_package_install_loc: 'http://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
-        opm_package_install_loc: 'http://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
+        oc_package_install_loc: 'http://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/openshift-client-linux.tar.gz'
+        opm_package_install_loc: 'http://mirror.openshift.com/pub/openshift-v4/{{ architecture_alias }}/clients/ocp/{{ openshift_client_version }}/opm-linux.tar.gz'
 
     - name: download OpenShift and OPM client tarballs
       ansible.builtin.include_tasks: '{{ role_path }}/tasks/download_client_tarballs.yml'

--- a/ansible/roles/ocp_install_cluster/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/main.yml
@@ -67,7 +67,7 @@
 
     - name: generate manifests using openshift-install binary
       ansible.builtin.command:
-        cmd: 'openshift-install create manifests --dir={{ openshift_installer_workdir }}'
+        cmd: '/usr/local/bin/openshift-install create manifests --dir={{ openshift_installer_workdir }}'
       environment:
         OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ openshift_release_image.stdout }}'
         OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE: '{{ openshift_rhcos_image_url_local }}'
@@ -139,7 +139,7 @@
 
 - name: trigger cluster installation using openshift-install binary
   ansible.builtin.command:
-    cmd: 'openshift-install create cluster --dir={{ openshift_installer_workdir }}'
+    cmd: '/usr/local/bin/openshift-install create cluster --dir={{ openshift_installer_workdir }}'
   environment:
     OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE: '{{ openshift_release_image.stdout }}'
     OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE: '{{ openshift_rhcos_image_url }}'

--- a/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
@@ -1,12 +1,12 @@
 apiVersion: v1
 baseDomain: {{ cluster_base_domain }}
 compute:
-- architecture: {{ ansible_architecture }}
+- architecture: {{ architecture_alias }}
   hyperthreading: Enabled
   name: worker
   replicas: {{ cluster_number_of_workers }}
 controlPlane:
-  architecture: {{ ansible_architecture }}
+  architecture: {{ architecture_alias }}
   hyperthreading: Enabled
   name: master
   replicas: 3

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -36,29 +36,40 @@
 
     - name: calculate cluster configuration hardware demands
       ansible.builtin.set_fact:
+        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers + openshift_infra_number_of_cpus * openshift_number_of_infra_nodes) / 2 }}'
         total_memory_required: '{{ openshift_master_memory_size * 3 + openshift_worker_memory_size * cluster_number_of_workers + openshift_infra_memory_size * openshift_number_of_infra_nodes }}'
         min_required_disk_space: '{{ (openshift_master_root_volume_size * 3 + openshift_worker_root_volume_size * cluster_number_of_workers + openshift_infra_root_volume_size * openshift_number_of_infra_nodes) / 5 }}'
       when: openshift_setup_dedicated_infra_nodes
 
     - name: calculate cluster configuration hardware demands
       ansible.builtin.set_fact:
+        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers) / 2 }}'
         total_memory_required: '{{ openshift_master_memory_size * 3 + openshift_worker_memory_size * cluster_number_of_workers }}'
         min_required_disk_space: '{{ (openshift_master_root_volume_size * 3 + openshift_worker_root_volume_size * cluster_number_of_workers) / 5 }}'
       when: not openshift_setup_dedicated_infra_nodes
+
+    - name: set current number of CPU cores detected
+      ansible.builtin.set_fact:
+        total_cpu_cores_detected: '{{ ansible_processor_vcpus }}'
+      when: ansible_architecture is inlist(['ppc64le', 'x86_64'])
+
+    - name: set current number of CPU cores detected
+      ansible.builtin.set_fact:
+        total_cpu_cores_detected: '{{ ansible_processor_cores }}'
+      when: ansible_architecture == 's390x'
 
     - name: ensure that the hardware demands can be met by the KVM host
       ansible.builtin.assert:
         that:
           - 'ansible_memtotal_mb > total_memory_required | int'
-          - 'ansible_processor_cores > openshift_worker_number_of_cpus'
+          - 'total_cpu_cores_detected | int >= total_cpu_cores_required | int'
           - 'libvirt_free_space | int >= min_required_disk_space | int'
         fail_msg: |-
           "The KVM host does not meet the hardware demands required by your OpenShift cluster configuration."
           "Make sure the host has at least:"
-          "{{ total_memory_required }} MB of RAM available"
-          "{{ ansible_processor_cores }} CPU cores available"
-          "{{ min_required_disk_space | int | human_readable(unit='G') }} free disk space available at /var/lib/libvirt"
-      when: 0 > 1
+          "{{ total_memory_required | int }} MB of RAM available (current: {{ ansible_memtotal_mb }} MB)"
+          "{{ total_cpu_cores_required | int }} CPU cores available (current: {{ total_cpu_cores_detected | int }} CPU cores)"
+          "{{ min_required_disk_space | int | human_readable(unit='G') }} free disk space available at /var/lib/libvirt (current: {{ libvirt_free_space | int | human_readable(unit='G') }})"
 
 - name: ensure KVM host isn't using incompatible OS-level packages
   block:

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
-- name: ensure the targeted KVM host is running RHEL 8.x on s390x
+- name: ensure the targeted KVM host is running RHEL 8.x on s390x / ppc64le / x86_64
   ansible.builtin.assert:
     that:
       - "ansible_os_family == 'RedHat'"
       - "ansible_distribution_major_version == '8'"
-      - "ansible_architecture == 's390x'"
+      - '{{ ansible_architecture is inlist(["s390x", "ppc64le", "x86_64"]) }}'
 
 - name: check if mandatory configuration variables are set
   ansible.builtin.assert:

--- a/ansible/roles/vbmc/tasks/main.yml
+++ b/ansible/roles/vbmc/tasks/main.yml
@@ -74,7 +74,7 @@
 
     - name: add master cluster nodes to vbmc
       ansible.builtin.command:
-        cmd: 'vbmc add {{ master_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index }}'
+        cmd: '/opt/vbmc/bin/vbmc add {{ master_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index }}'
       loop: '{{ master_domains | sort }}'
       loop_control:
         loop_var: master_node
@@ -82,7 +82,7 @@
 
     - name: add worker cluster nodes to vbmc
       ansible.builtin.command:
-        cmd: 'vbmc add {{ worker_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index + (master_domains | length) }}'
+        cmd: '/opt/vbmc/bin/vbmc add {{ worker_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index + (master_domains | length) }}'
       loop: '{{ worker_domains | sort }}'
       loop_control:
         loop_var: worker_node
@@ -96,7 +96,7 @@
 
         - name: add infrastructure cluster nodes to vbmc
           ansible.builtin.command:
-            cmd: 'vbmc add {{ infra_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index + ((master_domains + worker_domains) | length) }}'
+            cmd: '/opt/vbmc/bin/vbmc add {{ infra_node }} --username {{ vbmc_user }} --password {{ vbmc_password }} --address {{ vbmc_network_prefix }}.{{ vbmc_network_node_start + node_index + ((master_domains + worker_domains) | length) }}'
           loop: '{{ infra_domains | sort }}'
           loop_control:
             loop_var: infra_node
@@ -117,11 +117,11 @@
 
     - name: start vbmc nodes
       ansible.builtin.command:
-        cmd: "vbmc start {{ all_domains | join(' ') }}"
+        cmd: "/opt/vbmc/bin/vbmc start {{ all_domains | join(' ') }}"
 
     - name: list started vbmc nodes
       ansible.builtin.command:
-        cmd: 'vbmc list -f yaml'
+        cmd: '/opt/vbmc/bin/vbmc list -f yaml'
       register: vbmc_node_list
 
     - name: convert vbmc node list output to yaml
@@ -140,7 +140,7 @@
   block:
     - name: list started vbmc nodes
       ansible.builtin.command:
-        cmd: 'vbmc list -f yaml'
+        cmd: '/opt/vbmc/bin/vbmc list -f yaml'
       register: vbmc_node_list
 
     - name: convert vbmc node list output to yaml
@@ -163,7 +163,7 @@
   block:
     - name: list started vbmc nodes
       ansible.builtin.command:
-        cmd: 'vbmc list -f yaml'
+        cmd: '/opt/vbmc/bin/vbmc list -f yaml'
       register: vbmc_node_list
 
     - name: convert vbmc node list output to yaml

--- a/ansible/run_ocp_install.yml
+++ b/ansible/run_ocp_install.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   pre_tasks:
     - name: check the cluster image pull secret file exists on the Ansible controller

--- a/ansible/run_sanity_checks.yml
+++ b/ansible/run_sanity_checks.yml
@@ -1,0 +1,16 @@
+---
+
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
+
+  vars:
+    skip_libvirt_sanity_check: true
+
+  roles:
+    - role: sanity_check
+      tags:
+        - sanity
+        - preflight
+
+  tasks:
+    - ansible.builtin.debug:
+        msg: "Finished running sanity checks for KVM host '{{ inventory_hostname }}'. All done."

--- a/ansible/setup_host.yml
+++ b/ansible/setup_host.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   roles:
     - role: sanity_check

--- a/ansible/start_ocp_cluster_nodes.yml
+++ b/ansible/start_ocp_cluster_nodes.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   tasks:
     - name: start OpenShift cluster nodes

--- a/ansible/test_plugins/TestUtils.py
+++ b/ansible/test_plugins/TestUtils.py
@@ -11,6 +11,7 @@ class TestModule(object):
             'startswith': self.startswith,
             'contains': self.contains,
             'isrange': self.isrange,
+            'inlist': self.inlist,
         }
 
     '''
@@ -54,5 +55,18 @@ class TestModule(object):
     def isrange(self, input, start=0):
         try:
             return sorted(input) == list(range(start, max(input) + 1))
+        except TypeError:
+            return False
+
+    '''
+    Jinja2 test that checks if a given input string is member of a given list of values.
+
+    Parameters:
+    - input: the string that is to be checked if it is a member of a list of values
+    - values: the list of values that input will be checked against
+    '''
+    def inlist(self, input, values):
+        try:
+            return input in values
         except TypeError:
             return False

--- a/ansible/tune_ocp_install.yml
+++ b/ansible/tune_ocp_install.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: s390x_kvm_host
+- hosts: s390x_kvm_host,ppc64le_kvm_host,x86_64_kvm_host
 
   vars:
     cluster_tuned_annotation: 'kvm-ipi-automation-tuned'


### PR DESCRIPTION
## Related issue(s)

Resolves #35

## Description

This PR implements playbook changes to allow support for multiple KVM host architectures: s390x, ppc64le, x86_64.
Up until now the playbooks only supported s390x (which still remains the primary target platform and the only one in focus for further development of these playbooks).

Testing has been done on servers for all three supported architectures:

- s390x: IBM z14 LPAR, RHEL 8.4 and RHEL 8.5
- x86_64: Intel Xeon Platinum 8260 bare metal, RHEL 8.5
- ppc64le: IBM Power System LC922 bare metal, RHEL 8.5

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>