### PR TITLE
Using architecture-dependent CPU overcommit factor for sanity checks

### DIFF
--- a/ansible/group_vars/ppc64le_kvm_host.yml
+++ b/ansible/group_vars/ppc64le_kvm_host.yml
@@ -3,3 +3,5 @@
 # default settings that apply to all ppc64le_kvm_host hosts
 
 architecture_alias: ppc64le
+
+sanity_check_cpu_overcommit_factor: 4

--- a/ansible/group_vars/s390x_kvm_host.yml
+++ b/ansible/group_vars/s390x_kvm_host.yml
@@ -3,3 +3,5 @@
 # default settings that apply to all s390x_kvm_host hosts
 
 architecture_alias: s390x
+
+sanity_check_cpu_overcommit_factor: 10

--- a/ansible/group_vars/x86_64_kvm_host.yml
+++ b/ansible/group_vars/x86_64_kvm_host.yml
@@ -3,3 +3,5 @@
 # default settings that apply to all x86_64_kvm_host hosts
 
 architecture_alias: amd64
+
+sanity_check_cpu_overcommit_factor: 4

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -43,7 +43,7 @@
 
     - name: calculate cluster configuration hardware demands
       ansible.builtin.set_fact:
-        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers) / 2 }}'
+        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers) / sanity_check_cpu_overcommit_factor }}'
         total_memory_required: '{{ openshift_master_memory_size * 3 + openshift_worker_memory_size * cluster_number_of_workers }}'
         min_required_disk_space: '{{ (openshift_master_root_volume_size * 3 + openshift_worker_root_volume_size * cluster_number_of_workers) / 5 }}'
       when: not openshift_setup_dedicated_infra_nodes


### PR DESCRIPTION
## Related issue(s)

Resolves #59 

## Description

This PR introduces architecture-specific CPU overcommit factors for the built-in sanity checks.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>