### PR TITLE
Added OCM integration for cluster deletion during cleanup

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -8,3 +8,5 @@ terraform_ibm_provider_version: 1.38.0
 helm_version: 3.8.0
 
 butane_version: 0.14.0
+
+ocm_version: 0.1.62

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -339,3 +339,45 @@
         path: '{{ temp_dir.path }}'
         state: absent
       when: temp_dir.path is defined
+
+- name: compile and install ocm
+  block:
+    - name: create temporary download directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: ocm
+      register: temp_dir
+
+    - name: fetch ocm source code
+      ansible.builtin.git:
+        repo: 'https://github.com/openshift-online/ocm-cli.git'
+        dest: '{{ temp_dir.path }}/ocm-cli'
+        version: 'v{{ ocm_version }}'
+
+    - name: build ocm binary
+      ansible.builtin.command:
+        cmd: 'make all'
+        chdir: '{{ temp_dir.path }}/ocm-cli'
+      environment:
+        GOPATH: '{{ temp_dir.path }}/go'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+
+    - name: remove existing ocm binary from /usr/local/bin
+      ansible.builtin.file:
+        path: /usr/local/bin/ocm
+        state: absent
+
+    - name: copy ocm binary to /usr/local/bin
+      ansible.builtin.copy:
+        src: '{{ temp_dir.path }}/ocm-cli/ocm'
+        dest: /usr/local/bin/ocm
+        owner: root
+        group: root
+        mode: '0755'
+        remote_src: true
+  always:
+    - name: delete temporary download directory
+      ansible.builtin.file:
+        path: '{{ temp_dir.path }}'
+        state: absent
+      when: temp_dir.path is defined

--- a/ansible/roles/ocp_cleanup/defaults/main.yml
+++ b/ansible/roles/ocp_cleanup/defaults/main.yml
@@ -2,4 +2,4 @@
 
 cleanup_ignore_errors: false
 
-ocm_api_token_file: '{{ inventory_dir }}/secrets/ocm_api_token'
+ocm_api_token_file: '{{ inventory_dir }}/secrets/.ocm_api_token'

--- a/ansible/roles/ocp_cleanup/defaults/main.yml
+++ b/ansible/roles/ocp_cleanup/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 
 cleanup_ignore_errors: false
+
+ocm_api_token_file: '{{ inventory_dir }}/secrets/ocm_api_token'

--- a/ansible/roles/ocp_cleanup/tasks/archive_cluster_ocm.yml
+++ b/ansible/roles/ocp_cleanup/tasks/archive_cluster_ocm.yml
@@ -1,0 +1,59 @@
+---
+
+- name: check if the OCM API token file exists on the Ansible controller
+  ansible.builtin.stat:
+    path: '{{ ocm_api_token_file }}'
+  register: ocm_api_token_file_info
+  delegate_to: localhost
+
+- name: check if the ocm binary exists
+  ansible.builtin.stat:
+    path: /usr/local/bin/ocm
+  register: ocm_binary_info
+
+- name: archive the cluster in OCM
+  block:
+    - name: login to OCM
+      ansible.builtin.command:
+        cmd: '/usr/local/bin/ocm login --token={{ lookup("file", "{{ ocm_api_token_file }}") }}'
+
+    - name: create temporary working directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: ocmreq
+      register: temp_dir
+
+    - name: generate OCM request payload file
+      ansible.builtin.copy:
+        dest: '{{ temp_dir.path }}/subscription_patch.json'
+        content: '{{ subscription_patch | to_json }}'
+        owner: root
+        group: root
+        mode: '0777'
+      vars:
+        subscription_patch:
+          status: Archived
+
+    - name: determine Subscription resource in OCM assigned to cluster UID
+      ansible.builtin.command:
+        cmd: '/usr/local/bin/ocm get /api/accounts_mgmt/v1/subscriptions --parameter search="external_cluster_id = ''{{ external_cluster_id }}''"'
+      register: ocm_cluster_subscription
+
+    - name: patch Subscription resource in OCM to mark cluster as 'archived'
+      ansible.builtin.command:
+        cmd: '/usr/local/bin/ocm patch /api/accounts_mgmt/v1/subscriptions/{{ ocm_cluster_subscription.stdout | from_json | community.general.json_query("items[0].id") }} --body ''{{ temp_dir.path }}/subscription_patch.json'''
+      when: ocm_cluster_subscription is success
+  always:
+    - name: delete temporary download directory
+      ansible.builtin.file:
+        path: '{{ temp_dir.path }}'
+        state: absent
+      when: temp_dir.path is defined
+
+    - name: logout from OCM
+      ansible.builtin.command:
+        cmd: '/usr/local/bin/ocm logout'
+  when:
+    - ocm_api_token_file_info.stat.exists
+    - ocm_binary_info.stat.exists
+    - ocm_binary_info.stat.executable

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -35,6 +35,12 @@
   register: install_log_info
   when: workdir_info.stat.exists and workdir_info.stat.isdir
 
+- name: check if cluster installation kubeconfig file exists
+  ansible.builtin.stat:
+    path: '{{ openshift_installer_workdir }}/auth/kubeconfig'
+  register: install_kubeconfig_info
+  when: workdir_info.stat.exists and workdir_info.stat.isdir
+
 - name: check if openshift-install binary exists
   ansible.builtin.stat:
     path: /usr/local/bin/openshift-install
@@ -44,9 +50,16 @@
   ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/get_cluster_name.yml'
   when: workdir_info.stat.exists and workdir_info.stat.isdir and install_log_info.stat.exists
 
+- name: determine UID of existing cluster
+  ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/get_cluster_uid.yml'
+  when:
+    - workdir_info.stat.exists
+    - workdir_info.stat.isdir
+    - install_kubeconfig_info.stat.exists
+
 - name: destroy any existing cluster
   ansible.builtin.command:
-    cmd: 'openshift-install destroy cluster --dir={{ openshift_installer_workdir }}'
+    cmd: '/usr/local/bin/openshift-install destroy cluster --dir={{ openshift_installer_workdir }}'
   register: cluster_destroy
   when: workdir_info.stat.exists and workdir_info.stat.isdir and openshift_install_info.stat.exists
   ignore_errors: '{{ cleanup_ignore_errors }}'
@@ -66,6 +79,15 @@
       ansible.builtin.debug:
         var: stale_cluster_domains
   when: cluster_destroy is not skipped and cluster_destroy.rc != 0
+
+- name: archive cluster in OCM (if applicable)
+  ansible.builtin.include_tasks: '{{ role_path }}/tasks/archive_cluster_ocm.yml'
+  vars:
+    external_cluster_id: '{{ cluster_uid }}'
+  when:
+    - cluster_uid is defined
+    - cluster_destroy is not skipped
+    - cluster_destroy is success
 
 - name: remove all stale files and directories
   block:
@@ -144,7 +166,7 @@
       when: etc_resolv_conf_bkup_info.stat.exists
 
     - name: remove /etc/resolv.conf backup file
-      ansible.builtin.file:
+      ansible.builtin.file: # noqa risky-file-permissions
         path: /etc/resolv.conf.bkup
         attributes: '-i'
         state: '{{ item }}'

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -122,6 +122,7 @@
         - /usr/local/share/terraform/plugins/local/ibm-cloud/ibm
         - /usr/local/bin/helm
         - /usr/local/bin/butane
+        - /usr/local/bin/ocm
         - /etc/bash_completion.d/oc
 
 - name: check if SSH configuration for user root exists

--- a/ansible/secrets/README.md
+++ b/ansible/secrets/README.md
@@ -1,7 +1,18 @@
 # The purpose of this directory
 
-This directory is solely used to *temporarily* store the image pull secret file that is required to install an OpenShift cluster using IPI (installer-provisioned infrastructure) on a KVM host.
+This directory is solely used to *temporarily* store secrets that are used to install / manage an OpenShift cluster using IPI (installer-provisioned infrastructure) on a KVM host.
+
+These secrets are:
+
+- `.ocp_pull_secret` - OCP image pull secret file, required
+- `.ocm_api_token` - OCM API token, optional
+
+## .ocp_pull_secret
 
 Before you can use any of the Ansible playbooks in this repository you need to fetch this file from Red Hat and put it into this directory. Make sure the file is named `.ocp4_pull_secret` (hidden file, no extension) so that the Ansible playbooks will pick it up. If the file is missing or not named properly, the Ansible playbooks will fail to run (no worries, the playbooks have a sanity check implemented that will look for the image pull secret file before anything is done actually).
+
+## .ocm_api_token
+
+The Red Hat OpenShift Cluster Manager (OCM) is a portal that keeps track of all OCP cluster installations for a given Red Hat account / user ID. Upon deletion of an existing cluster on the target KVM host the information for that cluster can be archived in the OCM inventory, essentially marking a cluster as no longer subscribed / used. The `cleanup_ocp_install.yml` playbook can do that for you automatically, you just need to put a file named `.ocm_api_token` (hidden file, no extension) containing the OCM API token (see also: <https://console.redhat.com/openshift/token>) in this folder. OCM integration is completely optional, depending on the presence of `.ocm_api_token`.
 
 The `.gitignore` file in this directory will ensure that whatever you place in here will not be persisted in git.

--- a/ansible/tasks/get_cluster_uid.yml
+++ b/ansible/tasks/get_cluster_uid.yml
@@ -1,0 +1,13 @@
+---
+
+- name: get ClusterVersion object
+  kubernetes.core.k8s_info:
+    kubeconfig: '{{ openshift_installer_workdir }}/auth/kubeconfig'
+    api_version: 'config.openshift.io/v1'
+    kind: ClusterVersion
+    name: 'version'
+  register: cluster_version
+
+- name: set fact containing cluster UID
+  ansible.builtin.set_fact:
+    cluster_uid: '{{ cluster_version.resources[0].spec.clusterID }}'

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -188,6 +188,8 @@ cd ansible
 ansible-playbook -i inventory cleanup_ocp_install.yml [-e cleanup_ignore_errors=true]
 ```
 
+The cleanup playbook can also take care of de-registering the OpenShift cluster that is being destroyed from OpenShift Cluster Manager (OCM). For details on how to enable this OCM integration please refer to [here](../ansible/secrets/README.md).
+
 ## State of the KVM host after OpenShift cluster installation has finished successfully
 
 When the OpenShift cluster installation was successful you can interact with it in the usual ways. If you want to use the OpenShift client tooling from the command line (using `oc` or `kubectl`) you can do so by logging into the *root* user's account via SSH and just type away - the tools have been installed as part of the automated cluster installation via the Ansible playbooks. The 'kubeconfig' file is present in `/root/.kube/config` should you be looking for it.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -368,6 +368,7 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 │   │   ├── meta
 │   │   │   └── main.yml
 │   │   └── tasks
+│   │       ├── archive_cluster_ocm.yml
 │   │       └── main.yml
 │   ├── ocp_install_clients
 │   │   ├── defaults
@@ -452,6 +453,7 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 ├── tasks
 │   ├── check_cluster_state.yml
 │   ├── get_cluster_name.yml
+│   ├── get_cluster_uid.yml
 │   ├── reboot_host.yml
 │   ├── start_cluster_nodes.yml
 │   └── wait_for_cluster.yml

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,3 +37,30 @@ ansible-playbook -i inventory start_ocp_cluster_nodes.yml
 # check the OCP cluster for health issues (e.g. alerts)
 ansible-playbook -i inventory check_ocp_cluster_state.yml
 ```
+
+## Q: I am frequently setting up / tearing down OCP clusters. My OpenShift Cluster Manager (OCM) instance is littered with references to stale clusters that no longer exist. How do I get rid of these?
+
+A: Deleting clusters in state 'stale' in OCM is not possible at the moment. That said, there is a way to _archive_ stale clusters meaning moving them out of OCM's main view into a separate view called 'cluster archives'. Follow these steps to do that for your OCM instance:
+
+- download the latest `ocm` CLI binary to your Ansible workstation (see: <https://github.com/openshift-online/ocm-cli/releases>)
+- fetch your personal OCM API token from <https://console.redhat.com/openshift/token>
+- login to OCM via `ocm login --token=<your_api_token>`
+- run this shell script to archive all existing stale OCP clusters:
+  
+  ```bash
+  #/usr/bin/env bash
+
+  # create temporary OCM request payload file
+  cat <<EOF > sub.json
+  {
+    "status": "Archived"
+  }
+  EOF
+
+  # get all stale clusters from OCM and patch them with status 'Archived'
+  for i in $(ocm get /api/accounts_mgmt/v1/subscriptions --parameter size=1000 --parameter search="status in ('Stale')" | jq  -r ".items[].id"); do
+    ocm patch "/api/accounts_mgmt/v1/subscriptions/$i" --body 'sub.json'
+  done
+  ```
+
+You can also enable OCM integration with the playbooks in this repository so that whenever you delete an existing cluster via the `cleanup_ocp_install.yml` playbook it will be acrhived in OCM automatically. For details on how to enable this integration please see [here](../ansible/secrets/README.md).


### PR DESCRIPTION
## Related issue(s)

Resolves #66

## Description

This PR adds integration with OCM so that upon cluster deletion the cluster subscription info in OCM is updated.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>