### PR TITLE
Allow internet network type override

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,6 +18,8 @@ ansible_user: root
 
 openshift_installer_workdir: /root/ocp4-workdir
 
+openshift_network_type: OpenShiftSDN
+
 machine_network_prefix: 192.168.126
 machine_network_master_range: 10
 machine_network_worker_range: 50

--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -54,6 +54,11 @@ additional_host_ports:
   - 9200/tcp
   - 9300/tcp
 
+# the internal OpenShift network type
+# (this is the *internal* virtualized network for pod and service networks)
+# ATTENTION: must be either OpenShiftSDN (default) or OVNKubernetes
+openshift_network_type: OpenShiftSDN
+
 # the OpenShift cluster machine network prefix
 # (this is the network the OpenShift worker nodes (aka KVM guests) share to communicate to each other)
 # (see also: https://github.com/openshift/installer/blob/master/docs/user/customization.md)

--- a/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
@@ -19,7 +19,7 @@ networking:
     hostPrefix: {{ cluster_network_hostprefix }}
   machineNetwork:
   - cidr: {{ machine_network_prefix }}.0/24
-  networkType: OpenShiftSDN
+  networkType: {{ openshift_network_type }}
   serviceNetwork:
 {% for sn in service_networks %}
   - {{ sn }}


### PR DESCRIPTION
## Related issue(s)

Resolves #68 

## Description

This PR makes the internal OpenShift network type configurable by adding the host-specific configuration value `openshift_network_type`. The default network type is `OpenShiftSDN` (as previously) but can be overridden by the user.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
