### PR TITLE
Bumped package versions, changed OCP network type default

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,7 +18,7 @@ ansible_user: root
 
 openshift_installer_workdir: /root/ocp4-workdir
 
-openshift_network_type: OpenShiftSDN
+openshift_network_type: OVNKubernetes
 
 machine_network_prefix: 192.168.126
 machine_network_master_range: 10

--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 
-go_version: 1.17.6
+go_version: 1.17.8
 
-terraform_version: 1.1.3
-terraform_ibm_provider_version: 1.38.0
+terraform_version: 1.2.1
+terraform_ibm_provider_version: 1.41.1
 
-helm_version: 3.8.0
+helm_version: 3.9.0
 
 butane_version: 0.14.0
 


### PR DESCRIPTION
## Related issue(s)

Resolves #70

## Description

This PR contains version updates for some 3rd-party packages as well as an update to the default OpenShift cluster network type.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>