### PR TITLE
Added advanced cluster configuration capabilities

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -18,7 +18,7 @@ ansible_user: root
 
 openshift_installer_workdir: /root/ocp4-workdir
 
-openshift_network_type: OVNKubernetes
+openshift_network_type: OpenShiftSDN
 
 machine_network_prefix: 192.168.126
 machine_network_master_range: 10

--- a/ansible/host_files/.gitignore
+++ b/ansible/host_files/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/ansible/host_files/README.md
+++ b/ansible/host_files/README.md
@@ -1,0 +1,24 @@
+# The purpose of this directory
+
+This directory is used to store *advanced* cluster configuration files that are of importance to the OpenShift cluster installation process.
+
+These cluster configuration files are:
+
+- `cluster-network-03-config.yml` - OpenShift cluster network configuration file (see: <https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal/installing-bare-metal-network-customizations.html>)
+
+The cluster configuration files **must** be organized by KVM hosts, meaning that for every KVM host a specific configuration should be applied to a dedicated subdirectory must exist within this directory.
+
+For example:
+
+```bash
+/ansible
+...
+├── host_files
+│   ├── <my_kvm_host_name_1>
+│   │   └── cluster-network-03-config.yml
+│   └── <my_kvm_host_name_2>
+│       └── cluster-network-03-config.yml
+...
+```
+
+The `.gitignore` file in this directory will ensure that whatever you place in here will not be persisted in git.

--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -34,7 +34,7 @@ openshift_rhcos_image_url: 'https://mirror.openshift.com/pub/openshift-v4/{{ ans
 
 #############################################
 # --> optional variables that don't necessarily to be set
-# (these apply to all support server architectures)
+# (these apply to all supported server architectures)
 #############################################
 
 # the version of the OpenShift client tools to be installed on the KVM host
@@ -89,7 +89,7 @@ openshift_setup_dedicated_infra_nodes: false
 
 #############################################
 # <-- optional variables that don't necessarily to be set
-# (these apply to all support server architectures)
+# (these apply to all supported server architectures)
 #############################################
 
 #############################################

--- a/ansible/roles/ocp_install_cluster/tasks/copy_advanced_configuration_files.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/copy_advanced_configuration_files.yml
@@ -1,0 +1,17 @@
+---
+
+- name: check if advanced cluster configuration file exists
+  ansible.builtin.stat:
+    path: '{{ inventory_dir }}/host_files/{{ inventory_hostname }}/{{ advanced_config_file.name }}'
+  register: advanced_config_file_info
+  delegate_to: localhost
+
+- name: copy advanced cluster configuration file to target directory
+  ansible.builtin.copy:
+    src: '{{ inventory_dir }}/host_files/{{ inventory_hostname }}/{{ advanced_config_file.name }}'
+    dest: '{{ advanced_config_file.dest }}'
+    owner: root
+    group: root
+    mode: '0644'
+  when:
+    - advanced_config_file_info.stat.exists

--- a/ansible/roles/ocp_install_cluster/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/main.yml
@@ -134,6 +134,13 @@
       loop_control:
         loop_var: manifest
 
+- name: put files for advanced cluster configuration in place
+  ansible.builtin.include_tasks: '{{ role_path }}/tasks/copy_advanced_configuration_files.yml'
+  loop:
+    - { 'name': 'cluster-network-03-config.yml', 'dest': '{{ openshift_installer_workdir }}/manifests/cluster-network-03-config.yml' }
+  loop_control:
+    loop_var: advanced_config_file
+
 - name: determine name of to-be-created cluster from installation log
   ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/get_cluster_name.yml'
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -275,7 +275,7 @@ podman build . -t kvm-ipi-automation:base-latest --format docker
 Due to the way the The KVM IPI automation Docker image content has been structured, it's fairly easy to extend the image by adding additional Ansible roles or playbooks. The content of the Docker image is as follows (only the Ansible-related parts of the image are shown here):
 
 ```bash
-/ansible
+ansible
 ├── ansible.cfg
 ├── check_ocp_cluster_state.yml
 ├── cleanup_ocp_install.yml
@@ -288,6 +288,8 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 │   ├── ppc64le_kvm_host.yml
 │   ├── s390x_kvm_host.yml
 │   └── x86_64_kvm_host.yml
+├── host_files
+│   └── README.md
 ├── inventory.template
 ├── prepare_ocp_install.yml
 ├── reboot_host.yml
@@ -345,6 +347,8 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 │   │   │   └── main.yml
 │   │   └── tasks
 │   │       └── main.yml
+│   ├── named
+│   │   └── files
 │   ├── networking
 │   │   ├── files
 │   │   │   ├── dnsmasq.add-hosts.conf
@@ -355,7 +359,7 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 │   │   ├── tasks
 │   │   │   └── main.yml
 │   │   └── templates
-│   │   │   ├── dnsmasq.openshift.conf.j2
+│   │       ├── dnsmasq.openshift.conf.j2
 │   │       └── haproxy.cfg.j2
 │   ├── ocp_build_installer
 │   │   ├── defaults
@@ -388,6 +392,7 @@ Due to the way the The KVM IPI automation Docker image content has been structur
 │   │   ├── meta
 │   │   │   └── main.yml
 │   │   ├── tasks
+│   │   │   ├── copy_advanced_configuration_files.yml
 │   │   │   ├── main.yml
 │   │   │   ├── setup_infra_cluster_nodes.yml
 │   │   │   └── update_master_configuration.yml


### PR DESCRIPTION
## Related issue(s)

Resolves #72 

## Description

This PR adds the ability for users to supply advanced cluster configuration files that are used by the OpenShift installer to tweak different aspects of the cluster installation process and the resulting cluster itself, in particular for the cluster network settings.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
