### PR TITLE
Fixed regex for release version strinng to support pre-release build …

### DIFF
--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -22,7 +22,7 @@
 
     - name: determine version number of OpenShift release about to be installed
       ansible.builtin.set_fact:
-        ocp_release_ver: "{{ ocp_release_txt['content'] | b64decode | trim | regex_search('^Name:[\\s]*([\\d.]*)$', '\\1', multiline=true) | parse_version }}"
+        ocp_release_ver: "{{ ocp_release_txt['content'] | b64decode | trim | regex_search('^Name:[\\s]*([\\d.]*)', '\\1', multiline=true) | parse_version }}"
 
     - name: set openshift-install release version
       ansible.builtin.set_fact:


### PR DESCRIPTION
…installations

## Related issue(s)

Resolves #74

## Description

This PR provides a fix that will allow the user to install pre-release (aka nightly) builds of OCP on their target LPAR.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

