### PR TITLE
Allow custom network MTU size

### DIFF
--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -76,6 +76,10 @@ cluster_network: 10.128.0.0/14
 # (see also: https://github.com/openshift/installer/blob/master/docs/user/customization.md)
 cluster_network_hostprefix: 23
 
+# the MTU size of the OpenShift cluster network
+# ATTENTION: if this variable is not set the cluster network will use the builtin default MTU size (which depends on your actual host configuration)
+cluster_network_mtu: 1500
+
 # a list of OpenShift cluster service networks
 # (this are the networks the services running in the OpenShift cluster are using)
 # (see also: https://github.com/openshift/installer/blob/master/docs/user/customization.md)

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -38,6 +38,9 @@
         dest: '{{ temp_dir.path }}/installer'
         version: '{{ openshift_installer_version }}'
 
+    - name: patch openshift-install source code
+      ansible.builtin.include_tasks: '{{ role_path }}/tasks/patch_installer.yml'
+
     - name: build openshift-install binary
       ansible.builtin.command:
         cmd: 'hack/build.sh'

--- a/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
+++ b/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
@@ -1,0 +1,10 @@
+---
+
+- name: add custom MTU size to libvirt_network terraform resource
+  ansible.builtin.lineinfile:
+    path: '{{ temp_dir.path }}/installer/data/data/libvirt/cluster/main.tf'
+    line: '  mtu = "{{ cluster_network_mtu }}"'
+    insertafter: '^.*bridge = var.libvirt_network_if.*$'
+  when:
+    - cluster_network_mtu is defined
+    - cluster_network_mtu

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -365,7 +365,8 @@ ansible
 │   │   ├── meta
 │   │   │   └── main.yml
 │   │   └── tasks
-│   │       └── main.yml
+│   │       ├── main.yml
+│   │       └── patch_installer.yml
 │   ├── ocp_cleanup
 │   │   ├── defaults
 │   │   │   └── main.yml


### PR DESCRIPTION
## Related issue(s)

Resolves #76 

## Description

This PR adds a new per-host configuration setting that allows to define a custom cluster network MTU size for the new OpenShift cluster to be installed.

## DCO Sign-off
