### PR TITLE
Added example tekton resources

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,0 +1,117 @@
+# tekton
+
+This folder contains OpenShift Pipelines (Tekton) resources for various KVM host-related activities, e.g. installing RHOCP, rebooting the host, etc.
+Please consider these resources as examples (rather than ready-to-use resources) on how to utilize the Ansible playbooks in this repository from within an existing Red Hat OpenShift cluster that has OpenShift Pipelines (<https://docs.openshift.com/container-platform/4.11/cicd/pipelines/op-release-notes.html>) installed.
+
+## Overview
+
+The following resources are included in this folder:
+
+| Resource type | Name  | Purpose | Details |
+|---------------|-------|---------|---------|
+| Task | sleep | Generic task that will sleep for a given amount of time | |
+| Task | kvm-run-playbook | Run a given ocp-kvm-ipi-automation Ansible playbook against a KVM host | Uses the ocp-kvm-ipi-automation Docker image built by Pipeline 'build-kvm-deployer' |
+| Pipeline | build-kvm-deployer | Builds a Docker image for ocp-kvm-ipi-automation (using the Dockerfile in this repository) and stores it in the internal RHOCP image registry | |
+| Pipeline | deploy-ocp-kvm-host | Deploy RHOCP on a KVM host | Uses the Task 'kvm-run-playbook' |
+| Pipeline | cleanup-kvm-host | Uninstall RHOCP from a KVM host and clean up all remaining artifacts | Uses the Task 'kvm-run-playbook' |
+| Pipeline | reboot-kvm-host | Reboot a KVM host | Uses the Task 'kvm-run-playbook' |
+| Pipeline | tune-ocp-kvm-host | Tune the existing RHOCP installation on a KVM host | Uses the Task 'kvm-run-playbook' |
+
+## Usage
+
+The resources in this folder rely on a few thinsg that need to be setup before you can actually start using them.
+
+### Secrets
+
+The following secrets need to present at the time before any of the included pipelines and tasks is used:
+
+- name: kvm-deployer-ssh, type: Secret
+- name: kvm-deployer-secrets, type: Secret
+
+These secrets can be created by running the following commands:
+
+```bash
+# create kvm-deployer-ssh secret
+# first create a new SSH keypair and configure your target KVM host's root account to accept it as authorized key
+cd $HOME
+ssh-keygen -t rsa -f $HOME/.ssh/id_ansible
+ssh-copy-id -i $HOME/.ssh/id_ansible root@<YOUR_KVM_HOST_NAME>
+# afterwards create the secret containing the SSH keypair
+cd $HOME/.ssh
+oc project <YOUR_TEKTON_PROJECT>
+oc create secret generic kvm-deployer-ssh --from-file=id_ansible=./id_ansible --from-file=id_ansible.pub=./id_ansible.pub
+
+# create kvm-deployer-secrets secret
+cd $HOME
+# fetch your personal RHOCP image pull secret file from your Red Hat account and put it into $HOME/.ocp4_pull_secret
+# afterwards create the secret containing the RHOCP image pull secret
+oc project <YOUR_TEKTON_PROJECT>
+oc create secret generic kvm-deployer-secrets --from-file=.ocp4_pull_secret=./.ocp4_pull_secret
+```
+
+### KVM host configuration files
+
+KVM host configuration for the Pipeline resources must be done via a dedicated GitHub repository. All Pipeline resources make use of workspaces that get populated by fetching files from a remote repository, e.g.:
+
+```yaml
+...
+  tasks:
+  - name: fetch-config
+    params:
+    - name: url
+      value: $(params.configs-url)
+    - name: revision
+      value: $(params.configs-branch)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: configs
+...
+```
+
+For this to work make sure you create a new GitHub repository that is outlined like this:
+
+```bash
+.
+└── config
+    ├── MY_KVM_HOST_1
+    │   ├── host_vars
+    │   │   └── MY_KVM_HOST_1.yml
+    │   ├── inventory
+    │   └── ssh_config
+    ├── MY_KVM_HOST_2
+    │   ├── host_vars
+    │   │   └── MY_KVM_HOST_2.yml
+    │   ├── inventory
+    │   └── ssh_config
+    ├── ...
+```
+
+You'll recognize the `inventory` files as well as the host-specific configuration YAML files in the `host_vars` subfolders - these are required by the Ansible playbooks. Please refer to the [documentation](../docs/DOCUMENTATION.md) for more details on those files.
+
+The `ssh_config` file is required for the 'kvm-deployer' pod that is part of the pipelines to actually make a SSH connection to the target KVM host to be able to run the Ansible playbooks. Make sure the `ssh_config` file looks like this:
+
+```text
+ForwardX11 no
+ForwardX11Trusted no
+GSSAPIAuthentication no
+HashKnownHosts yes
+
+Host *
+  ConnectTimeout 90
+  IdentitiesOnly yes
+  PermitLocalCommand yes
+  ServerAliveInterval 60
+  ServerAliveCountMax 5
+  TCPKeepAlive yes
+
+Host MY_KVM_HOST_1
+  HostName MY_KVM_HOST_1
+  User root
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  IdentityFile ~/.ssh/id_ansible
+  LogLevel ERROR
+```

--- a/tekton/pipelines/build-kvm-deployer.yaml
+++ b/tekton/pipelines/build-kvm-deployer.yaml
@@ -1,0 +1,53 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-kvm-deployer
+spec:
+  description: Build kvm-deployer image
+  params:
+  - name: repo-url
+    description: The URL of the git repository that is to be fetched
+    type: string
+    default: https://github.com/ibm-s390-cloud/ocp-kvm-ipi-automation.git
+  - name: branch-name
+    description: The name of the branch to fetch from the git repository
+    type: string
+    default: main
+  - name: image-tag
+    description: The Docker image tag to use for the final image
+    type: string
+    default: latest
+  tasks:
+  - name: fetch-repo
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: source
+  - name: build-image
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: DOCKERFILE
+      value: $(workspaces.source.path)/Dockerfile
+    - name: IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/kvm-deployer:$(params.image-tag)
+    runAfter:
+    - fetch-repo
+    taskRef:
+      kind: ClusterTask
+      name: buildah
+    workspaces:
+    - name: source
+      workspace: source
+  workspaces:
+  - description: This workspace will be used to stored the fetched git repository
+    name: source

--- a/tekton/pipelines/cleanup-kvm-host.yaml
+++ b/tekton/pipelines/cleanup-kvm-host.yaml
@@ -1,0 +1,55 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cleanup-kvm-host
+spec:
+  params:
+  - description: Name of the target KVM host that will be cleaned up
+    name: host
+    type: string
+  - description: Force cleanup of the KVM host
+    name: force-cleanup
+    type: string
+    default: 'false'
+  - description: URL of the git repository containing the cluster configuration data
+    name: configs-url
+    type: string
+  - description: Name of the git repository branch from which to fetch cluster configuration data
+    name: configs-branch
+    type: string
+    default: main
+  tasks:
+  - name: fetch-config
+    params:
+    - name: url
+      value: $(params.configs-url)
+    - name: revision
+      value: $(params.configs-branch)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: configs
+  - name: kvm-run-playbook
+    params:
+    - name: host
+      value: $(params.host)
+    - name: playbook
+      value: cleanup_ocp_install.yml
+    - name: flags
+      value:
+      - '-e cleanup_ignore_errors=$(params.force-cleanup)'
+    runAfter:
+    - fetch-config
+    taskRef:
+      kind: Task
+      name: kvm-run-playbook
+    timeout: "1h"
+    workspaces:
+    - name: configs
+      workspace: configs
+  workspaces:
+  - name: configs

--- a/tekton/pipelines/deploy-ocp-kvm-host.yaml
+++ b/tekton/pipelines/deploy-ocp-kvm-host.yaml
@@ -1,0 +1,56 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy-ocp-kvm-host
+spec:
+  params:
+  - description: Name of the target KVM host that OCP will be deployed on
+    name: host
+    type: string
+  - description: URL of the git repository containing the cluster configuration data
+    name: configs-url
+    type: string
+  - description: Name of the git repository branch from which to fetch cluster configuration data
+    name: configs-branch
+    type: string
+    default: main
+  tasks:
+  - name: fetch-config
+    params:
+    - name: url
+      value: $(params.configs-url)
+    - name: revision
+      value: $(params.configs-branch)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: configs
+  - name: kvm-run-playbook
+    params:
+    - name: host
+      value: $(params.host)
+    - name: playbook
+      value: site.yml
+    runAfter:
+    - fetch-config
+    taskRef:
+      kind: Task
+      name: kvm-run-playbook
+    timeout: "2h"
+    workspaces:
+    - name: configs
+      workspace: configs
+  finally:
+  - name: cluster-reconcile-sleep
+    params:
+    - name: duration
+      value: "300"
+    taskRef:
+      kind: Task
+      name: sleep
+  workspaces:
+  - name: configs

--- a/tekton/pipelines/reboot-kvm-host.yaml
+++ b/tekton/pipelines/reboot-kvm-host.yaml
@@ -1,0 +1,48 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: reboot-kvm-host
+spec:
+  params:
+  - description: Name of the target KVM host that will be rebooted
+    name: host
+    type: string
+  - description: URL of the git repository containing the cluster configuration data
+    name: configs-url
+    type: string
+  - description: Name of the git repository branch from which to fetch cluster configuration data
+    name: configs-branch
+    type: string
+    default: main
+  tasks:
+  - name: fetch-config
+    params:
+    - name: url
+      value: $(params.configs-url)
+    - name: revision
+      value: $(params.configs-branch)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: configs
+  - name: kvm-run-playbook
+    params:
+    - name: host
+      value: $(params.host)
+    - name: playbook
+      value: reboot_host.yml
+    runAfter:
+    - fetch-config
+    taskRef:
+      kind: Task
+      name: kvm-run-playbook
+    timeout: "30m"
+    workspaces:
+    - name: configs
+      workspace: configs
+  workspaces:
+  - name: configs

--- a/tekton/pipelines/tune-ocp-kvm-host.yaml
+++ b/tekton/pipelines/tune-ocp-kvm-host.yaml
@@ -1,0 +1,56 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: tune-ocp-kvm-host
+spec:
+  params:
+  - description: Name of the target KVM host whose OCP cluster will be tuned
+    name: host
+    type: string
+  - description: URL of the git repository containing the cluster configuration data
+    name: configs-url
+    type: string
+  - description: Name of the git repository branch from which to fetch cluster configuration data
+    name: configs-branch
+    type: string
+    default: main
+  tasks:
+  - name: fetch-config
+    params:
+    - name: url
+      value: $(params.configs-url)
+    - name: revision
+      value: $(params.configs-branch)
+    taskRef:
+      kind: ClusterTask
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: configs
+  - name: kvm-run-playbook
+    params:
+    - name: host
+      value: $(params.host)
+    - name: playbook
+      value: tune_ocp_install.yml
+    runAfter:
+    - fetch-config
+    taskRef:
+      kind: Task
+      name: kvm-run-playbook
+    timeout: "2h"
+    workspaces:
+    - name: configs
+      workspace: configs
+  finally:
+  - name: cluster-reconcile-sleep
+    params:
+    - name: duration
+      value: "300"
+    taskRef:
+      kind: Task
+      name: sleep
+  workspaces:
+  - name: configs

--- a/tekton/tasks/kvm-run-playbook.yaml
+++ b/tekton/tasks/kvm-run-playbook.yaml
@@ -1,0 +1,72 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kvm-run-playbook
+spec:
+  params:
+  - description: Name of the target KVM host
+    name: host
+    type: string
+  - default: site.yml
+    description: Name of the Ansible playbook that will be run
+    name: playbook
+    type: string
+  - name: flags
+    description: An array of additional Ansible playbook flags
+    type: array
+    default: []
+  steps:
+  - image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/kvm-deployer:latest
+    imagePullPolicy: Always
+    name: kvm-prepare
+    resources: {}
+    script: |
+      #!/usr/bin/env bash
+      # workaround for volume mount permission issue
+      mkdir -p -m 0700 /root/.ssh
+      cp /ansible/keys/id_ansible* /root/.ssh/
+      cp $(workspaces.configs.path)/config/$(params.host)/ssh_config /root/.ssh/config
+      chmod 400 /root/.ssh/id_ansible
+      chmod 640 /root/.ssh/id_ansible.pub /root/.ssh/config
+      # install Python3 on the target KVM host (required by subsequent Ansible step)
+      ssh $(params.host) "yum install -y python3"
+    volumeMounts:
+    - mountPath: /ansible/keys
+      name: ssh
+      readOnly: true
+  - image: image-registry.openshift-image-registry.svc:5000/$(context.taskRun.namespace)/kvm-deployer:latest
+    imagePullPolicy: Always
+    name: kvm-playbook
+    resources: {}
+    args: ["$(params.flags[*])"]
+    script: |
+      #!/usr/bin/env bash
+      # workaround for volume mount permission issue
+      mkdir -p -m 0700 /root/.ssh
+      cp /ansible/keys/id_ansible* /root/.ssh/
+      cp $(workspaces.configs.path)/config/$(params.host)/ssh_config /root/.ssh/config
+      chmod 400 /root/.ssh/id_ansible
+      chmod 640 /root/.ssh/id_ansible.pub /root/.ssh/config
+      # copy files in place
+      cp -R $(workspaces.configs.path)/config/$(params.host)/host_vars /ansible
+      cp $(workspaces.configs.path)/config/$(params.host)/inventory /ansible/inventory
+      # run Ansible playbook
+      ansible-playbook $(params.playbook) --limit $(params.host) $@
+    volumeMounts:
+    - mountPath: /ansible/secrets
+      name: secrets
+    - mountPath: /ansible/keys
+      name: ssh
+      readOnly: true
+  volumes:
+  - name: secrets
+    secret:
+      secretName: kvm-deployer-secrets
+  - name: ssh
+    secret:
+      defaultMode: 256
+      secretName: kvm-deployer-ssh
+  workspaces:
+  - name: configs

--- a/tekton/tasks/sleep.yaml
+++ b/tekton/tasks/sleep.yaml
@@ -1,0 +1,19 @@
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sleep
+spec:
+  params:
+  - description: Sleep duration in seconds
+    name: duration
+    type: string
+    default: "60"
+  steps:
+  - image: registry.access.redhat.com/ubi9-micro
+    imagePullPolicy: IfNotPresent
+    name: sleep
+    script: |
+      #!/usr/bin/env bash
+      sleep $(params.duration)


### PR DESCRIPTION
## Related issue(s)

Resolves #63 

## Description

This PR adds tekton / OpenShift Pipelines resources that enable the use of the Ansible playbooks in this repo from within a tekton-enabled cluster.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
