### PR TITLE
Bumped base image to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-38
+FROM registry.access.redhat.com/ubi8/python-39
 
 # use 'root' user throughout the whole image
 USER root


### PR DESCRIPTION
## Related issue(s)

Resolves #82 

## Description

This PR bumps the base image in Dockerfile to Python 3.9.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>