### PR TITLE
Ensure target host is running at least RHEL 8.6

### DIFF
--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -111,7 +111,6 @@
         state: present
         disable_gpg_check: true
       when: "ansible_architecture == 's390x'"
-  when: 0 > 1
 
 - name: upgrade essential Python packages
   ansible.builtin.pip:

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -111,6 +111,7 @@
         state: present
         disable_gpg_check: true
       when: "ansible_architecture == 's390x'"
+  when: 0 > 1
 
 - name: upgrade essential Python packages
   ansible.builtin.pip:

--- a/ansible/roles/crypto/README.md
+++ b/ansible/roles/crypto/README.md
@@ -86,7 +86,7 @@ The `setname` property will always reflect the internal cluster ID of the OpenSh
 
 ## Optional: installing the EP11 binaries on the KVM host
 
-The crypto resources enablement playbook allows you to automatically install the EP11 binaries on the KVM host. As these binaries are not part of the underlying RHEL 8.x distribution but need to be downloaded separately from IBM this installation step is completely optional and will be skipped if the binaries are not provided by the user. The most recent EP11 binaries (available as RPM or Debian packages) can be obtained from this website: <https://www.ibm.com/resources/mrs/assets?source=ibmzep11>.
+The crypto resources enablement playbook allows you to automatically install the EP11 binaries on the KVM host. As these binaries are not part of the underlying RHEL 8 distribution but need to be downloaded separately from IBM this installation step is completely optional and will be skipped if the binaries are not provided by the user. The most recent EP11 binaries (available as RPM or Debian packages) can be obtained from this website: <https://www.ibm.com/resources/mrs/assets?source=ibmzep11>.
 
 Make sure to download at least the following files:
 

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 
-- name: ensure the targeted KVM host is running RHEL 8.x on s390x / ppc64le / x86_64 / aarch64
+- name: ensure the targeted KVM host is running RHEL 8.6 (or later) on s390x / ppc64le / x86_64 / aarch64
   ansible.builtin.assert:
     that:
       - "ansible_os_family == 'RedHat'"
       - "ansible_distribution_major_version == '8'"
+      - '{{ (ansible_distribution_version | parse_version)["minor"] >= 6 }}'
       - '{{ ansible_architecture is inlist(["s390x", "ppc64le", "x86_64", "aarch64"]) }}'
 
 - name: check if mandatory configuration variables are set

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -10,7 +10,7 @@ In order to run the Ansible playbooks in this repository you need:
 
 - an Ansible **compatible** workstation (a dedicated standalone workstation that is physically separate from the target Linux host)
 - a working **Ansible 2.10 (or newer)** installation on your workstation
-- a suitably powerful Linux host running RHEL 8.x (tested with RHEL 8.4 and RHEL 8.5) with an **active** Red Hat subscription using one of the following hardware architectures:
+- a suitably powerful Linux host running RHEL 8.6 with an **active** Red Hat subscription using one of the following hardware architectures:
   - s390x (an IBM zSystems / LinuxONE LPAR, supported: z13 / z14 / z15 / z16)
   - ppc64le (an IBM Power Systems bare metal host or LPAR, supported: POWER9)
   - x86_64 (an Intel- or AMD-based bare metal host)
@@ -109,7 +109,7 @@ Once you've finished with these preparations you can proceed to the actual OpenS
 
 ### Linux host
 
-**You need to start with a vanilla installation of RHEL 8.x! This is very important as any existing KVM-based OpenShift cluster installation or remaining artifacts / configuration snippets thereof are very likely to interfere with the different setup and configuration steps done by these playbooks.**
+**You need to start with a vanilla installation of RHEL 8.6! This is very important as any existing KVM-based OpenShift cluster installation or remaining artifacts / configuration snippets thereof are very likely to interfere with the different setup and configuration steps done by these playbooks.**
 
 Once the initial RHEL OS installation is done, simply transfer your public SSH key to the target Linux host's *root* user account:
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -10,7 +10,7 @@ In order to run the Ansible playbooks in this repository you need:
 
 - an Ansible **compatible** workstation (a dedicated standalone workstation that is physically separate from the target Linux host)
 - a working **Ansible 2.10 (or newer)** installation on your workstation
-- a suitably powerful Linux host running RHEL 8.6 with an **active** Red Hat subscription using one of the following hardware architectures:
+- a suitably powerful Linux host running RHEL 8.6 (or later) with an **active** Red Hat subscription using one of the following hardware architectures:
   - s390x (an IBM zSystems / LinuxONE LPAR, supported: z13 / z14 / z15 / z16)
   - ppc64le (an IBM Power Systems bare metal host or LPAR, supported: POWER9)
   - x86_64 (an Intel- or AMD-based bare metal host)


### PR DESCRIPTION
## Related issue(s)

Resolves #84 

## Description

This PR ensures that the playbooks only support target hosts running at least RHEL 8.6. This change was mandated by updated Python3 prerequites and their dependency on rust 1.56 (which is not available on older RHEL 8 releases).

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
