### PR TITLE
Added Feora36 support and Ansible linter fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,7 +3,12 @@ quiet: true
 skip_list:
   - command-instead-of-module
   - no-changed-when
+  - name[casing]
+  - schema[meta]
+  - yaml[line-length]
 exclude_paths:
+  - .github/
+  - docs/
   - tekton/
 use_default_rules: true
 verbosity: 1

--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -331,6 +331,7 @@ os_packages:
       - python3-libvirt
       - python3-libselinux
       - python3-libsemanage
+      - python3-wheel
       - ipmitool
       - gcc
       - gcc-c++
@@ -485,6 +486,159 @@ os_packages:
       - python3-libvirt
       - python3-libselinux
       - python3-libsemanage
+      - python3-wheel
+      - ipmitool
+      - gcc
+      - gcc-c++
+      - git-lfs
+      - clang
+      - jq
+      - lsof
+      - net-tools
+      - httpd
+      - fio
+      - bash-completion
+  '36_0':
+    groups:
+      - '@RPM Development Tools'
+      - '@Development Tools'
+    modules:
+      # mimics @virt:rhel/common
+      - hivex
+      - hivex-devel
+      - libguestfs
+      - libguestfs-appliance
+      - libguestfs-bash-completion
+      - libguestfs-devel
+      - libguestfs-gfs2
+      - libguestfs-gobject
+      - libguestfs-gobject-devel
+      - libguestfs-rescue
+      - libguestfs-rsync
+      - libguestfs-xfs
+      - libiscsi
+      - libiscsi-devel
+      - libiscsi-utils
+      - libnbd
+      - libnbd-bash-completion
+      - libnbd-devel
+      - libtpms
+      - libtpms-devel
+      - libvirt
+      - libvirt-client
+      - libvirt-daemon
+      - libvirt-daemon-config-network
+      - libvirt-daemon-config-nwfilter
+      - libvirt-daemon-driver-interface
+      - libvirt-daemon-driver-network
+      - libvirt-daemon-driver-nodedev
+      - libvirt-daemon-driver-nwfilter
+      - libvirt-daemon-driver-qemu
+      - libvirt-daemon-driver-secret
+      - libvirt-daemon-driver-storage
+      - libvirt-daemon-driver-storage-core
+      - libvirt-daemon-driver-storage-disk
+      - libvirt-daemon-driver-storage-iscsi
+      - libvirt-daemon-driver-storage-logical
+      - libvirt-daemon-driver-storage-mpath
+      - libvirt-daemon-driver-storage-rbd
+      - libvirt-daemon-driver-storage-scsi
+      - libvirt-daemon-kvm
+      - libvirt-dbus
+      - libvirt-devel
+      - libvirt-docs
+      - libvirt-libs
+      - libvirt-lock-sanlock
+      - libvirt-nss
+      - libvirt-wireshark
+      - lua-guestfs
+      - nbdfuse
+      - nbdkit
+      - nbdkit-bash-completion
+      - nbdkit-basic-filters
+      - nbdkit-basic-plugins
+      - nbdkit-curl-plugin
+      - nbdkit-devel
+      - nbdkit-example-plugins
+      - nbdkit-gzip-filter
+      - nbdkit-linuxdisk-plugin
+      - nbdkit-nbd-plugin
+      - nbdkit-python-plugin
+      - nbdkit-server
+      - nbdkit-ssh-plugin
+      - nbdkit-tar-filter
+      - nbdkit-tmpdisk-plugin
+      - nbdkit-xz-filter
+      - perl-Sys-Guestfs
+      - perl-Sys-Virt
+      - perl-hivex
+      - python3-hivex
+      - python3-libguestfs
+      - python3-libnbd
+      - python3-libvirt
+      - qemu-guest-agent
+      - qemu-img
+      - qemu-kvm
+      - qemu-kvm-core
+      - ruby-hivex
+      - ruby-libguestfs
+      - supermin
+      - supermin-devel
+      - swtpm
+      - swtpm-libs
+      - swtpm-tools
+      - virt-dib
+      # mimics @rust-toolset:rhel8/common
+      - cargo
+      - cargo-doc
+      - clippy
+      - rls
+      - rust
+      - rust-analysis
+      - rust-doc
+      - rust-gdb
+      - rust-lldb
+      - rust-src
+      - rust-std-static
+      - rustfmt
+    rpms:
+      - bind-utils
+      - iputils
+      - podman
+      - tmux
+      - wget
+      - curl
+      - vim-enhanced
+      - rsync
+      - genisoimage
+      - qemu-img
+      - qemu-kvm
+      - libvirt
+      - libvirt-daemon-config-network
+      - libvirt-daemon-kvm
+      - libvirt-client
+      - virt-install
+      - virt-manager
+      - libguestfs-tools-c
+      - openssl
+      - openssl-devel
+      - libffi
+      - libffi-devel
+      - policycoreutils-python-utils
+      - python3-jmespath
+      - python3-jsonpatch
+      - python3-pyyaml
+      - python3-pip
+      - python3-devel
+      - python3-netaddr
+      - python3-policycoreutils
+      - python3-setuptools
+      - python3-lxml
+      - python3-firewall
+      - python3-libvirt
+      - python3-libselinux
+      - python3-libsemanage
+      - python3-wheel
       - ipmitool
       - gcc
       - gcc-c++
@@ -548,6 +702,15 @@ python_packages:
     required:
       - openshift==0.13.1
       - pyOpenSSL==22.0.0
+      - stormssh==0.7.0
+      - virtualenv==20.16.5
+      - xmltodict==0.13.0
+  '36_0':
+    essential:
+      - pip==21.3.1
+    required:
+      - openshift==0.13.1
+      - pyOpenSSL==21.0.0
       - stormssh==0.7.0
       - virtualenv==20.16.5
       - xmltodict==0.13.0

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -56,9 +56,9 @@
 
 - name: install prerequisite Python packages
   ansible.builtin.pip:
-    name:  '{{ item }}'
+    name: '{{ item }}'
     state: present
-    extra_args: '--no-cache-dir --ignore-installed'
+    extra_args: '--no-cache-dir --ignore-installed --prefer-binary'
   loop:
     - '{{ python_packages[os_version]["essential"] }}'
     - '{{ python_packages[os_version]["required"] }}'

--- a/ansible/roles/crypto/files/cex-plugin-daemonset.yaml
+++ b/ansible/roles/crypto/files/cex-plugin-daemonset.yaml
@@ -16,44 +16,44 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
       initContainers:
-      - name: shadowsysfs
-        image: 'registry.redhat.io/ubi8-minimal'
-        command: ["/bin/sh"]
-        args: ["-c", "mkdir -p -m 0755 /var/tmp/shadowsysfs && chcon -t container_file_t /var/tmp/shadowsysfs"]
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: vartmp
-            mountPath: /var/tmp
+        - name: shadowsysfs
+          image: 'registry.redhat.io/ubi8-minimal'
+          command: ["/bin/sh"]
+          args: ["-c", "mkdir -p -m 0755 /var/tmp/shadowsysfs && chcon -t container_file_t /var/tmp/shadowsysfs"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: vartmp
+              mountPath: /var/tmp
       containers:
-      - image: 'registry.connect.redhat.com/ibm/ibm-cex-device-plugin-cm:v1.0.0'
-        imagePullPolicy: Always
-        name: cex-plugin
-        securityContext:
-          privileged: true
-        env:
-          - name: NODENAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: APQN_OVERCOMMIT_LIMIT
-            value: "1"
-        volumeMounts:
-          - name: device-plugin
-            mountPath: /var/lib/kubelet/device-plugins
-          - name: pod-resources
-            mountPath: /var/lib/kubelet/pod-resources
-          - name: vartmp
-            mountPath: /var/tmp
-          - name: dev
-            mountPath: /dev
-          - name: sys
-            mountPath: /sys
-          - name: cex-resources-conf
-            mountPath: /config/
+        - image: 'registry.connect.redhat.com/ibm/ibm-cex-device-plugin-cm:v1.0.0'
+          imagePullPolicy: Always
+          name: cex-plugin
+          securityContext:
+            privileged: true
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: APQN_OVERCOMMIT_LIMIT
+              value: "1"
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: pod-resources
+              mountPath: /var/lib/kubelet/pod-resources
+            - name: vartmp
+              mountPath: /var/tmp
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: cex-resources-conf
+              mountPath: /config/
       volumes:
         - name: device-plugin
           hostPath:

--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -2,14 +2,17 @@
 
 - name: configure NetworkManager
   block:
-    - name: remove immutability attribute from /etc/resolv.conf file
-      ansible.builtin.command:
-        cmd: 'chattr -i /etc/resolv.conf'
+    - name: determine location of resolv.conf file
+      ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/get_resolv_conf_location.yml'
 
-    - name: create backup of /etc/resolv.conf file
+    - name: remove immutability attribute from resolv.conf file
+      ansible.builtin.command:
+        cmd: 'chattr -i {{ resolv_conf_location }}'
+
+    - name: create backup of resolv.conf file
       ansible.builtin.copy:
-        src: /etc/resolv.conf
-        dest: /etc/resolv.conf.bkup
+        src: '{{ resolv_conf_location }}'
+        dest: '{{ resolv_conf_location }}.bkup'
         owner: root
         group: root
         mode: '0644'
@@ -53,21 +56,21 @@
         state: reloaded
         enabled: true
 
-    - name: slurp original of /etc/resolv.conf file from backup
+    - name: slurp original of resolv.conf file from backup
       ansible.builtin.slurp:
-        src: /etc/resolv.conf.bkup
-      register: original_etc_resolv_conf
+        src: '{{ resolv_conf_location }}.bkup'
+      register: original_resolv_conf
 
-    - name: retain any nameserver settings from the original /etc/resolv.conf file
+    - name: retain any nameserver settings from the original resolv.conf file
       ansible.builtin.lineinfile:
-        path: /etc/resolv.conf
+        path: '{{ resolv_conf_location }}'
         line: '{{ item }}'
         insertafter: '^nameserver.*$'
-      loop: "{{ original_etc_resolv_conf['content'] | b64decode | trim | regex_findall('^nameserver.*$', multiline=true) }}"
+      loop: "{{ original_resolv_conf['content'] | b64decode | trim | regex_findall('^nameserver.*$', multiline=true) }}"
   always:
-    - name: add immutability attribute to /etc/resolv.conf file
+    - name: add immutability attribute to resolv.conf file
       ansible.builtin.command:
-        cmd: 'chattr +i /etc/resolv.conf'
+        cmd: 'chattr +i {{ resolv_conf_location }}'
 
 - name: configure haproxy
   block:

--- a/ansible/roles/ocp_cleanup/tasks/main.yml
+++ b/ansible/roles/ocp_cleanup/tasks/main.yml
@@ -14,7 +14,7 @@
       ansible.builtin.shell:
         cmd: 'ip a | grep {{ ipmi_dummy_network }}'
       register: dummy_net_link
-      failed_when: dummy_net_link.rc not in [0,1]
+      failed_when: dummy_net_link.rc not in [0, 1]
 
     - name: delete the dummy network interface
       ansible.builtin.command:
@@ -145,39 +145,42 @@
     - '{{ libvirt_marker }}'
     - '{{ host_marker }}'
 
-- name: clean up /etc/resolv.conf
+- name: clean up resolv.conf
   block:
-    - name: remove immutability attribute from /etc/resolv.conf file
+    - name: determine location of resolv.conf file
+      ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/get_resolv_conf_location.yml'
+
+    - name: remove immutability attribute from resolv.conf file
       ansible.builtin.command:
-        cmd: 'chattr -i /etc/resolv.conf'
+        cmd: 'chattr -i {{ resolv_conf_location }}'
 
-    - name: check if /etc/resolv.conf backup file exists
+    - name: check if resolv.conf backup file exists
       ansible.builtin.stat:
-        path: /etc/resolv.conf.bkup
-      register: etc_resolv_conf_bkup_info
+        path: '{{ resolv_conf_location }}.bkup'
+      register: resolv_conf_bkup_info
 
-    - name: restore original /etc/resolv.conf from backup file
+    - name: restore original resolv.conf from backup file
       ansible.builtin.copy:
-        src: /etc/resolv.conf.bkup
-        dest: /etc/resolv.conf
+        src: '{{ resolv_conf_location }}.bkup'
+        dest: '{{ resolv_conf_location }}'
         owner: root
         group: root
         mode: '0644'
         remote_src: true
-      when: etc_resolv_conf_bkup_info.stat.exists
+      when: resolv_conf_bkup_info.stat.exists
 
-    - name: remove /etc/resolv.conf backup file
+    - name: remove resolv.conf backup file
       ansible.builtin.file: # noqa risky-file-permissions
-        path: /etc/resolv.conf.bkup
+        path: '{{ resolv_conf_location }}.bkup'
         attributes: '-i'
         state: '{{ item }}'
       loop:
         - touch
         - absent
   always:
-    - name: add immutability attribute to /etc/resolv.conf file
+    - name: add immutability attribute to resolv.conf file
       ansible.builtin.command:
-        cmd: 'chattr +i /etc/resolv.conf'
+        cmd: 'chattr +i {{ resolv_conf_location }}'
 
 - name: clean up libvirt hooks
   block:

--- a/ansible/roles/ocp_install_cluster/files/03_openshift-machineconfigpool_infra-0.yaml
+++ b/ansible/roles/ocp_install_cluster/files/03_openshift-machineconfigpool_infra-0.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}
+      - { key: machineconfiguration.openshift.io/role, operator: In, values: [worker, infra] }
   maxUnavailable: null
   nodeSelector:
     matchLabels:

--- a/ansible/roles/ocp_install_cluster/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/main.yml
@@ -108,12 +108,12 @@
     - name: update worker configuration
       ansible.utils.update_fact:
         updates:
-        - path: openshift_worker_config.spec.template.spec.providerSpec.value.volume.volumeSize
-          value: '{{ openshift_worker_root_volume_size }}'
-        - path: openshift_worker_config.spec.template.spec.providerSpec.value.domainMemory
-          value: '{{ openshift_worker_memory_size }}'
-        - path: openshift_worker_config.spec.template.spec.providerSpec.value.domainVcpu
-          value: '{{ openshift_worker_number_of_cpus }}'
+          - path: openshift_worker_config.spec.template.spec.providerSpec.value.volume.volumeSize
+            value: '{{ openshift_worker_root_volume_size }}'
+          - path: openshift_worker_config.spec.template.spec.providerSpec.value.domainMemory
+            value: '{{ openshift_worker_memory_size }}'
+          - path: openshift_worker_config.spec.template.spec.providerSpec.value.domainVcpu
+            value: '{{ openshift_worker_number_of_cpus }}'
       register: updated
 
     - name: write back worker configuration to manifest file

--- a/ansible/roles/ocp_install_cluster/tasks/update_master_configuration.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/update_master_configuration.yml
@@ -12,12 +12,12 @@
 - name: update master configuration
   ansible.utils.update_fact:
     updates:
-    - path: openshift_master_config.spec.providerSpec.value.volume.volumeSize
-      value: '{{ openshift_master_root_volume_size }}'
-    - path: openshift_master_config.spec.providerSpec.value.domainMemory
-      value: '{{ openshift_master_memory_size }}'
-    - path: openshift_master_config.spec.providerSpec.value.domainVcpu
-      value: '{{ openshift_master_number_of_cpus }}'
+      - path: openshift_master_config.spec.providerSpec.value.volume.volumeSize
+        value: '{{ openshift_master_root_volume_size }}'
+      - path: openshift_master_config.spec.providerSpec.value.domainMemory
+        value: '{{ openshift_master_memory_size }}'
+      - path: openshift_master_config.spec.providerSpec.value.domainVcpu
+        value: '{{ openshift_master_number_of_cpus }}'
   register: updated
 
 - name: write back master configuration to manifest file

--- a/ansible/roles/ocp_install_cluster_wrapup/tasks/persist_ssh_config.yml
+++ b/ansible/roles/ocp_install_cluster_wrapup/tasks/persist_ssh_config.yml
@@ -51,7 +51,7 @@
 
     - name: set /etc/hosts cluster nodes fact
       ansible.builtin.set_fact:
-        cluster_nodes_etc_hosts: '{{ (cluster_nodes_etc_hosts | default([])) + [ item.host.ip + " " + item.host.name.split(".")[0] ] }}'
+        cluster_nodes_etc_hosts: '{{ (cluster_nodes_etc_hosts | default([])) + [item.host.ip + " " + item.host.name.split(".")[0]] }}'
       loop: '{{ libvirt_cluster_nodes.matches }}'
       when: not "bootstrap" in item.host.name
 

--- a/ansible/roles/sanity_check/tasks/main.yml
+++ b/ansible/roles/sanity_check/tasks/main.yml
@@ -29,10 +29,10 @@
 
     - name: check Fedora prerequisites
       block:
-        - name: ensure that the major Fedora version is 35
+        - name: ensure that the major Fedora version is 35 or 36
           ansible.builtin.assert:
             that:
-              - '{{ ansible_distribution_major_version is inlist(["35"]) }}'
+              - '{{ ansible_distribution_major_version is inlist(["35", "36"]) }}'
       when: "ansible_distribution == 'Fedora'"
 
 - name: ensure the targeted KVM host architecture is supported by KVM (RHEL only)

--- a/ansible/roles/tuning/files/50-enable-rfs.yaml
+++ b/ansible/roles/tuning/files/50-enable-rfs.yaml
@@ -10,16 +10,16 @@ spec:
       version: 3.2.0
     storage:
       files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,IyB0dXJuIG9uIFJlY2VpdmUgRmxvdyBTdGVlcmluZyAoUkZTKSBmb3IgYWxsIG5ldHdvcmsgaW50ZXJmYWNlcwpTVUJTWVNURU09PSJuZXQiLCBBQ1RJT049PSJhZGQiLCBSVU57cHJvZ3JhbX0rPSIvYmluL2Jhc2ggLWMgJ2ZvciB4IGluIC9zeXMvJERFVlBBVEgvcXVldWVzL3J4LSo7IGRvIGVjaG8gODE5MiA+ICR4L3Jwc19mbG93X2NudDsgZG9uZSciCg==
-        mode: 420
-        overwrite: true
-        path: /etc/udev/rules.d/71-net-tunings.rules
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,IyBkZWZpbmUgc29jayBmbG93IGVudHJpZXMgZm9yIFJlY2VpdmUgRmxvdyBTdGVlcmluZyAoUkZTKQpuZXQuY29yZS5ycHNfc29ja19mbG93X2VudHJpZXM9ODE5Mgo=
-        mode: 420
-        overwrite: true
-        path: /etc/sysctl.d/95-enable-rfs.conf
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,IyB0dXJuIG9uIFJlY2VpdmUgRmxvdyBTdGVlcmluZyAoUkZTKSBmb3IgYWxsIG5ldHdvcmsgaW50ZXJmYWNlcwpTVUJTWVNURU09PSJuZXQiLCBBQ1RJT049PSJhZGQiLCBSVU57cHJvZ3JhbX0rPSIvYmluL2Jhc2ggLWMgJ2ZvciB4IGluIC9zeXMvJERFVlBBVEgvcXVldWVzL3J4LSo7IGRvIGVjaG8gODE5MiA+ICR4L3Jwc19mbG93X2NudDsgZG9uZSciCg==
+          mode: 420
+          overwrite: true
+          path: /etc/udev/rules.d/71-net-tunings.rules
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,IyBkZWZpbmUgc29jayBmbG93IGVudHJpZXMgZm9yIFJlY2VpdmUgRmxvdyBTdGVlcmluZyAoUkZTKQpuZXQuY29yZS5ycHNfc29ja19mbG93X2VudHJpZXM9ODE5Mgo=
+          mode: 420
+          overwrite: true
+          path: /etc/sysctl.d/95-enable-rfs.conf
   extensions: null
   fips: false
   kernelArguments: null

--- a/ansible/roles/tuning/files/thp-workers-profile.yaml
+++ b/ansible/roles/tuning/files/thp-workers-profile.yaml
@@ -5,16 +5,16 @@ metadata:
   namespace: openshift-cluster-node-tuning-operator
 spec:
   profile:
-  - data: |
-      [main]
-      summary=Custom tuned profile for RHOCP on IBM zSystems to turn off THP on worker nodes
-      include=openshift-node
+    - data: |
+        [main]
+        summary=Custom tuned profile for RHOCP on IBM zSystems to turn off THP on worker nodes
+        include=openshift-node
 
-      [vm]
-      transparent_hugepages=never
-    name: openshift-thp-never-worker
+        [vm]
+        transparent_hugepages=never
+      name: openshift-thp-never-worker
   recommend:
-  - match:
-    - label: node-role.kubernetes.io/worker
-    priority: 35
-    profile: openshift-thp-never-worker
+    - match:
+        - label: node-role.kubernetes.io/worker
+      priority: 35
+      profile: openshift-thp-never-worker

--- a/ansible/roles/tuning/tasks/main.yml
+++ b/ansible/roles/tuning/tasks/main.yml
@@ -75,7 +75,7 @@
 
     - name: bump CPU shares for worker nodes
       ansible.builtin.include_tasks: '{{ role_path }}/tasks/libvirt_set_cpu_shares.yml'
-      loop: '{{ worker_domains | product([ domain_cpu_shares.worker ]) | list }}'
+      loop: '{{ worker_domains | product([domain_cpu_shares.worker]) | list }}'
       loop_control:
         loop_var: cluster_node_share
   always:

--- a/ansible/tasks/check_cluster_state.yml
+++ b/ansible/tasks/check_cluster_state.yml
@@ -16,7 +16,7 @@
 
     - name: find non-ready (defunct) Nodes
       ansible.builtin.set_fact:
-        nonready_nodes: '{{ (nonready_nodes | default([])) + [ item | get_resources(state="Ready", status="Unknown|False") ] | select() | list }}'
+        nonready_nodes: '{{ (nonready_nodes | default([])) + [item | get_resources(state="Ready", status="Unknown|False")] | select() | list }}'
       loop: '{{ all_existing_nodes.resources }}'
       loop_control:
         label: '{{ item.metadata.name }}'
@@ -37,7 +37,7 @@
 
     - name: find unavailable (defunct) ClusterOperators
       ansible.builtin.set_fact:
-        unavailable_cos: '{{ (unavailable_cos | default([])) + [ item | get_resources(state="Available", status="False") ] | select() | list }}'
+        unavailable_cos: '{{ (unavailable_cos | default([])) + [item | get_resources(state="Available", status="False")] | select() | list }}'
       loop: '{{ all_existing_cos.resources }}'
       loop_control:
         label: '{{ item.metadata.name }}'
@@ -112,7 +112,7 @@
 
     - name: filter the list of current alerts to remove default alerts
       ansible.builtin.set_fact:
-        real_alerts: '{{ (real_alerts | default([])) + [ item ] if item }}'
+        real_alerts: '{{ (real_alerts | default([])) + [item] if item }}'
       loop: '{{ ocp_prometheus_alert_results.json.data | to_json | from_json | community.general.json_query(alerts_query) }}'
       vars:
         alerts_query: "alerts[?labels.alertname!='Watchdog' && labels.alertname!='AlertmanagerReceiversNotConfigured'].labels.alertname || [`0`]"
@@ -138,7 +138,7 @@
 
 - name: add cluster state facts to list
   ansible.builtin.set_fact:
-    cluster_state_facts: '{{ (cluster_stats_facts | default([])) + [ item ] }}'
+    cluster_state_facts: '{{ (cluster_stats_facts | default([])) + [item] }}'
   loop:
     - '{{ has_nonready_nodes }}'
     - '{{ has_unavailable_cos }}'

--- a/ansible/tasks/get_resolv_conf_location.yml
+++ b/ansible/tasks/get_resolv_conf_location.yml
@@ -1,0 +1,27 @@
+---
+
+- name: determine file stats of /etc/resolv.conf file
+  ansible.builtin.stat:
+    path: /etc/resolv.conf
+  register: etc_resolv_conf_info
+
+- name: convert /etc/resolv.conf into a regular file (if symlink)
+  block:
+    - name: remove symlink /etc/resolv.conf
+      ansible.builtin.file:
+        path: /etc/resolv.conf
+        state: absent
+
+    - name: copy symlink source to /etc/resolv.conf
+      ansible.builtin.copy:
+        src: '{{ etc_resolv_conf_info.stat.lnk_source }}'
+        dest: /etc/resolv.conf
+        owner: root
+        group: root
+        mode: '0644'
+        remote_src: true
+  when: etc_resolv_conf_info.stat.exists and etc_resolv_conf_info.stat.islnk
+
+- name: set resolv.conf file location fact
+  ansible.builtin.set_fact:
+    resolv_conf_location: '/etc/resolv.conf'

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -17,6 +17,7 @@ In order to run the Ansible playbooks in this repository you need:
     - RHEL 8.6 (with an **active** Red Hat subscription)
     - RHEL 9.0 (with an **active** Red Hat subscription)
     - Fedora 35
+    - Fedora 36
   - using one of the following hardware architectures:
     - s390x (an IBM zSystems / LinuxONE LPAR, supported: z13 / z14 / z15 / z16)
     - ppc64le (an IBM Power Systems bare metal host or LPAR, supported: POWER9)
@@ -468,6 +469,7 @@ ansible
 │   ├── check_cluster_state.yml
 │   ├── get_cluster_name.yml
 │   ├── get_cluster_uid.yml
+│   ├── get_resolv_conf_location.yml
 │   ├── reboot_host.yml
 │   ├── start_cluster_nodes.yml
 │   └── wait_for_cluster.yml


### PR DESCRIPTION
## Related issue(s)

Resolves #90 

## Description
This PR enables the use of Fedora 36 as host OS for the target KVM host. It also fixes Ansible linter violations that were introduced with the latest version of 'ansible-lint'.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
