### PR TITLE
Enabled FIPS mode support

### DIFF
--- a/ansible/host_vars/host.yml.template
+++ b/ansible/host_vars/host.yml.template
@@ -91,6 +91,10 @@ service_networks:
 # (see also: https://docs.openshift.com/container-platform/4.9/machine_management/creating-infrastructure-machinesets.html)
 openshift_setup_dedicated_infra_nodes: false
 
+# whether to setup the OpenShift cluster in FIPS mode
+# (see also: https://docs.openshift.com/container-platform/4.10/installing/installing-fips.html)
+openshift_setup_fips_mode: false
+
 #############################################
 # <-- optional variables that don't necessarily to be set
 # (these apply to all supported server architectures)

--- a/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
@@ -24,7 +24,7 @@ networking:
 {% for sn in service_networks %}
   - {{ sn }}
 {% endfor %}
-
+fips: {{ fips_mode | bool | to_json }}
 platform:
   libvirt:
     network:

--- a/ansible/run_ocp_install.yml
+++ b/ansible/run_ocp_install.yml
@@ -23,6 +23,10 @@
       ansible.builtin.set_fact:
         vbmc_ipmi: '{{ setup_vbmc_ipmi | default(true) }}'
 
+    - name: check if the cluster is to be installed in FIPS mode
+      ansible.builtin.set_fact:
+        fips_mode: '{{ openshift_setup_fips_mode | default(false) }}'
+
   roles:
     - role: sanity_check
       tags:

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -309,6 +309,7 @@ ansible
 │   │   ├── meta
 │   │   │   └── main.yml
 │   │   └── tasks
+│   │       ├── install_python_packages.yml
 │   │       └── main.yml
 │   ├── common
 │   │   ├── meta


### PR DESCRIPTION
## Related issue(s)

Resolves #94 

## Description

This PR enables support for installing OCP in FIPS mode.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
