### PR TITLE
Fixed typo

### DIFF
--- a/ansible/secrets/README.md
+++ b/ansible/secrets/README.md
@@ -4,7 +4,7 @@ This directory is solely used to *temporarily* store secrets that are used to in
 
 These secrets are:
 
-- `.ocp_pull_secret` - RHOCP image pull secret file, required
+- `.ocp4_pull_secret` - RHOCP image pull secret file, required
 - `.ocm_api_token` - OCM API token, optional
 
 ## .ocp_pull_secret


### PR DESCRIPTION
## Related issue(s)

Resolves #100 

## Description

This PR fixes a typo in the playbook documentation which referred to the OCP pull secret file with an incorrect name.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
