### PR TITLE
Add warning if custom MTU size is unsupported

### DIFF
--- a/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
+++ b/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
@@ -1,10 +1,24 @@
 ---
 
+- name: determine file stats of main cluster terraform file
+  ansible.builtin.stat:
+    path: '{{ temp_dir.path }}/installer/data/data/libvirt/cluster/main.tf'
+  register: cluster_main_tf_file_info
+
 - name: add custom MTU size to libvirt_network terraform resource
   ansible.builtin.lineinfile:
     path: '{{ temp_dir.path }}/installer/data/data/libvirt/cluster/main.tf'
     line: '  mtu = "{{ cluster_network_mtu }}"'
     insertafter: '^.*bridge = var\.libvirt_network_if.*$'
   when:
+    - cluster_main_tf_file_info.stat.exists
     - cluster_network_mtu is defined
     - cluster_network_mtu
+
+- name: let the user know that configuring a custom MTU size is not supported
+  ansible.builtin.debug:
+    msg:
+      - "Your host-specific configuration YAML file contains a custom MTU size setting."
+      - "The OpenShift release you want to install however does not support custom MTU sizes."
+      - "So we simple ignore the custom MTU size setting and continue anyway."
+  when: not cluster_main_tf_file_info.stat.exists

--- a/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
+++ b/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
@@ -21,4 +21,7 @@
       - "Your host-specific configuration YAML file contains a custom MTU size setting."
       - "The OpenShift release you want to install however does not support custom MTU sizes."
       - "So we simple ignore the custom MTU size setting and continue anyway."
-  when: not cluster_main_tf_file_info.stat.exists
+  when:
+    - not cluster_main_tf_file_info.stat.exists
+    - cluster_network_mtu is defined
+    - cluster_network_mtu


### PR DESCRIPTION
## Related issue(s)

Resolves #104 

## Description

This PR attempts to handle OCP installation that aren't able to handle custom MTU sizes as reported in issue #104

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>