### PR TITLE
Haubenr support single node clusters

### DIFF
--- a/ansible/roles/networking/tasks/main.yml
+++ b/ansible/roles/networking/tasks/main.yml
@@ -128,6 +128,8 @@
       ansible.builtin.set_fact:
         etc_hosts_template:
           - '{{ ansible_default_ipv4.address }}'
+          - 'api.{{ cluster_name }}.{{ cluster_base_domain }}'
+          - 'api-int.{{ cluster_name }}.{{ cluster_base_domain }}'
           - 'noobaa-mgmt-openshift-storage.apps.{{ cluster_name }}.{{ cluster_base_domain }}'
           - 'alertmanager-main-openshift-monitoring.apps.{{ cluster_name }}.{{ cluster_base_domain }}'
           - 'console-openshift-console.apps.{{ cluster_name }}.{{ cluster_base_domain }}'

--- a/ansible/roles/networking/templates/haproxy.cfg.j2
+++ b/ansible/roles/networking/templates/haproxy.cfg.j2
@@ -2,67 +2,82 @@
 # OpenShift API frontend
 #---------------------------------------------------------------------
 frontend {{ cluster_name }}-kubeapi
-   mode tcp
-   option tcplog
-   bind *:6443
+  mode tcp
+  option tcplog
+  bind *:6443
 
-   tcp-request inspect-delay 5s
-   tcp-request content accept if { req_ssl_hello_type 1 }
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
 
-   acl {{ cluster_name }} req_ssl_sni -m end .{{ cluster_name }}.{{ cluster_base_domain }}
-   use_backend {{ cluster_name }}-kubeapi if {{ cluster_name }}
+  acl {{ cluster_name }} req_ssl_sni -m end .{{ cluster_name }}.{{ cluster_base_domain }}
+  use_backend {{ cluster_name }}-kubeapi if {{ cluster_name }}
 
 #---------------------------------------------------------------------
 # OpenShift API backend
 #---------------------------------------------------------------------
 backend {{ cluster_name }}-kubeapi
-   mode tcp
-   balance source
-   server {{ cluster_name }}-master-0 {{ machine_network_prefix }}.{{ machine_network_master_range + 1 }}:6443 check
-   server {{ cluster_name }}-master-1 {{ machine_network_prefix }}.{{ machine_network_master_range + 2 }}:6443 check
-   server {{ cluster_name }}-master-2 {{ machine_network_prefix }}.{{ machine_network_master_range + 3 }}:6443 check
+  mode tcp
+  balance source
+  server {{ cluster_name }}-bootstrap {{ machine_network_prefix }}.{{ machine_network_master_range }}:6443 check
+{% for master_index in range(0, (cluster_number_of_masters | default(3, true) | int), 1) %}
+  server {{ cluster_name }}-master-{{ master_index }} {{ machine_network_prefix }}.{{ machine_network_master_range + 1 + master_index }}:6443 check
+{% endfor %}
 
 #---------------------------------------------------------------------
 # OpenShift HTTPS frontend
 #---------------------------------------------------------------------
 frontend {{ cluster_name }}-https
-   mode tcp
-   option tcplog
-   bind *:443
+  mode tcp
+  option tcplog
+  bind *:443
 
-   tcp-request inspect-delay 5s
-   tcp-request content accept if { req_ssl_hello_type 1 }
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
 
-   acl {{ cluster_name }} req_ssl_sni -m end .{{ cluster_name }}.{{ cluster_base_domain }}
-   use_backend {{ cluster_name }}-https if {{ cluster_name }}
+  acl {{ cluster_name }} req_ssl_sni -m end .{{ cluster_name }}.{{ cluster_base_domain }}
+  use_backend {{ cluster_name }}-https if {{ cluster_name }}
 
 #---------------------------------------------------------------------
 # OpenShift HTTPS backend
 #---------------------------------------------------------------------
 backend {{ cluster_name }}-https
-   mode tcp
-   balance source
-   {% for worker_index in range(0, cluster_number_of_workers | int, 1) %}
-   server {{ cluster_name }}-worker-{{ worker_index }} {{ machine_network_prefix }}.{{ machine_network_worker_range + 1 + worker_index }}:443 check
-   {% endfor %}
+  mode tcp
+  balance source
+{% if (cluster_number_of_workers | int) > 0 %}
+{% for worker_index in range(0, cluster_number_of_workers | int, 1) %}
+  server {{ cluster_name }}-worker-{{ worker_index }} {{ machine_network_prefix }}.{{ machine_network_worker_range + 1 + worker_index }}:443 check
+{% endfor %}
+{% endif %}
+{% if (cluster_number_of_masters | default(3, true) | int) == 1 %}
+{% for master_index in range(0, cluster_number_of_masters | int, 1) %}
+  server {{ cluster_name }}-master-{{ master_index }} {{ machine_network_prefix }}.{{ machine_network_master_range + 1 + master_index }}:443 check
+{% endfor %}
+{% endif %}
 
 #---------------------------------------------------------------------
 # OpenShift HTTP frontend
 #---------------------------------------------------------------------
 frontend {{ cluster_name }}-http
-   mode http
-   option tcplog
-   bind *:80
+  mode http
+  option tcplog
+  bind *:80
 
-   acl {{ cluster_name }} hdr(host) -m end .{{ cluster_name }}.{{ cluster_base_domain }}
-   use_backend {{ cluster_name }}-http if {{ cluster_name }}
+  acl {{ cluster_name }} hdr(host) -m end .{{ cluster_name }}.{{ cluster_base_domain }}
+  use_backend {{ cluster_name }}-http if {{ cluster_name }}
 
 #---------------------------------------------------------------------
 # OpenShift HTTP backend
 #---------------------------------------------------------------------
 backend {{ cluster_name }}-http
-   mode http
-   balance source
-   {% for worker_index in range(0, cluster_number_of_workers | int, 1) %}
-   server {{ cluster_name }}-worker-{{ worker_index }} {{ machine_network_prefix }}.{{ machine_network_worker_range + 1 + worker_index }}:80 check
-   {% endfor %}
+  mode http
+  balance source
+{% if (cluster_number_of_workers | int) > 0 %}
+{% for worker_index in range(0, cluster_number_of_workers | int, 1) %}
+  server {{ cluster_name }}-worker-{{ worker_index }} {{ machine_network_prefix }}.{{ machine_network_worker_range + 1 + worker_index }}:80 check
+{% endfor %}
+{% endif %}
+{% if (cluster_number_of_masters | default(3, true) | int) == 1 %}
+{% for master_index in range(0, cluster_number_of_masters | int, 1) %}
+  server {{ cluster_name }}-master-{{ master_index }} {{ machine_network_prefix }}.{{ machine_network_master_range + 1 + master_index }}:80 check
+{% endfor %}
+{% endif %}

--- a/ansible/roles/ocp_install_cluster/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/main.yml
@@ -246,6 +246,8 @@
       ansible.builtin.command:
         cmd: 'kill -USR2 {{ collect_data_process.stdout }}'
 
-- name: setup dedicated infrastructure cluster nodes
+- name: setup dedicated infrastructure cluster nodes (multi-node cluster configurations only)
   ansible.builtin.include_tasks: '{{ role_path }}/tasks/setup_infra_cluster_nodes.yml'
-  when: openshift_setup_dedicated_infra_nodes
+  when:
+    - openshift_setup_dedicated_infra_nodes
+    - cluster_number_of_masters is undefined

--- a/ansible/roles/ocp_install_cluster/tasks/main.yml
+++ b/ansible/roles/ocp_install_cluster/tasks/main.yml
@@ -28,6 +28,11 @@
         - openshift_release_image.rc != 0
         - openshift_release_image.stdout | length == 0
 
+    - name: generate list of master manifests
+      ansible.builtin.set_fact:
+        master_manifests: '{{ (master_manifests | default([])) + ["99_openshift-cluster-api_master-machines-" + item | string + ".yaml"] }}'
+      loop: '{{ range(0, (cluster_number_of_masters | default(3, true)) | int, 1) | list }}'
+
 - name: create OpenShift installation manifests
   block:
     - name: put the OpenShift installation configuration file in place
@@ -73,17 +78,23 @@
         OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE: '{{ openshift_rhcos_image_url_local }}'
 
     - name: check if manifests have been created successfully
-      ansible.builtin.stat:
-        path: '{{ item }}'
-      register: file_info
-      failed_when: not file_info.stat.exists
-      loop:
-        - '{{ openshift_installer_workdir }}/manifests'
-        - '{{ openshift_installer_workdir }}/openshift'
-        - '{{ openshift_installer_workdir }}/openshift/99_openshift-cluster-api_worker-machineset-0.yaml'
-        - '{{ openshift_installer_workdir }}/openshift/99_openshift-cluster-api_master-machines-0.yaml'
-        - '{{ openshift_installer_workdir }}/openshift/99_openshift-cluster-api_master-machines-1.yaml'
-        - '{{ openshift_installer_workdir }}/openshift/99_openshift-cluster-api_master-machines-2.yaml'
+      block:
+        - name: get common manifest file stats
+          ansible.builtin.stat:
+            path: '{{ item }}'
+          register: file_info
+          failed_when: not file_info.stat.exists
+          loop:
+            - '{{ openshift_installer_workdir }}/manifests'
+            - '{{ openshift_installer_workdir }}/openshift'
+            - '{{ openshift_installer_workdir }}/openshift/99_openshift-cluster-api_worker-machineset-0.yaml'
+
+        - name: get master nodes manifest file stats
+          ansible.builtin.stat:
+            path: '{{ openshift_installer_workdir }}/openshift/{{ item }}'
+          register: file_info
+          failed_when: not file_info.stat.exists
+          loop: '{{ master_manifests }}'
 
     - name: create backup of manifests (for debugging purposes)
       ansible.posix.synchronize:
@@ -127,12 +138,10 @@
 
     - name: update master manifests
       ansible.builtin.include_tasks: '{{ role_path }}/tasks/update_master_configuration.yml'
-      loop:
-        - 99_openshift-cluster-api_master-machines-0.yaml
-        - 99_openshift-cluster-api_master-machines-1.yaml
-        - 99_openshift-cluster-api_master-machines-2.yaml
+      loop: '{{ master_manifests }}'
       loop_control:
         loop_var: manifest
+        index_var: master_node_index
 
 - name: put files for advanced cluster configuration in place
   ansible.builtin.include_tasks: '{{ role_path }}/tasks/copy_advanced_configuration_files.yml'
@@ -193,7 +202,7 @@
 
         - name: add DNS records to the libvirt cluster network
           ansible.builtin.command:
-            cmd: 'virsh net-update --network {{ cluster_id }} --command add-last --section dns-host --xml {{ temp_dir.path }}/libvirt_network_dns.xml --live --config'
+            cmd: 'virsh net-update --network {{ cluster_id }} --command add --section dns-host --xml {{ temp_dir.path }}/libvirt_network_dns.xml --live --config'
       always:
         - name: delete temporary directory
           ansible.builtin.file:

--- a/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
+++ b/ansible/roles/ocp_install_cluster/templates/install-config.yaml.j2
@@ -9,7 +9,7 @@ controlPlane:
   architecture: {{ architecture_alias }}
   hyperthreading: Enabled
   name: master
-  replicas: 3
+  replicas: {{ cluster_number_of_masters | default(3, true) }}
 metadata:
   creationTimestamp: null
   name: {{ cluster_name }}

--- a/ansible/roles/ocp_install_cluster/templates/libvirt_network_dns_xml.j2
+++ b/ansible/roles/ocp_install_cluster/templates/libvirt_network_dns_xml.j2
@@ -1,4 +1,6 @@
 <host ip='{{ machine_network_prefix }}.1'>
+  <hostname>api.{{ cluster_name }}.{{ cluster_base_domain }}</hostname>
+  <hostname>api-int.{{ cluster_name }}.{{ cluster_base_domain }}</hostname>
   <hostname>noobaa-mgmt-openshift-storage.apps.{{ cluster_name }}.{{ cluster_base_domain }}</hostname>
   <hostname>alertmanager-main-openshift-monitoring.apps.{{ cluster_name }}.{{ cluster_base_domain }}</hostname>
   <hostname>console-openshift-console.apps.{{ cluster_name }}.{{ cluster_base_domain }}</hostname>

--- a/ansible/roles/soundness_check/tasks/main.yml
+++ b/ansible/roles/soundness_check/tasks/main.yml
@@ -55,20 +55,34 @@
           "https://ibm.biz/BdPYsd"
 
 - name: check if mandatory configuration variables are set
-  ansible.builtin.assert:
-    that: '{{ item }}'
-  loop:
-    - cluster_base_domain is defined and cluster_base_domain | trim | length > 0
-    - cluster_name is defined and cluster_base_domain | trim | length > 0
-    - cluster_number_of_workers is defined and cluster_number_of_workers | int > 0
-    - openshift_master_root_volume_size is defined and openshift_master_root_volume_size | int > 0
-    - openshift_master_number_of_cpus is defined and openshift_master_number_of_cpus | int > 0
-    - openshift_master_memory_size is defined and openshift_master_memory_size | int > 0
-    - openshift_worker_root_volume_size is defined and openshift_worker_root_volume_size | int > 0
-    - openshift_worker_number_of_cpus is defined and openshift_worker_number_of_cpus | int > 0
-    - openshift_worker_memory_size is defined and openshift_worker_memory_size | int > 0
-    - openshift_release_url is defined and openshift_release_url | trim | length > 0
-    - openshift_rhcos_image_url is defined and openshift_rhcos_image_url | trim | length > 0
+  block:
+    - name: check for common configuration variables
+      ansible.builtin.assert:
+        that: '{{ item }}'
+      loop:
+        - cluster_base_domain is defined and cluster_base_domain | trim | length > 0
+        - cluster_name is defined and cluster_base_domain | trim | length > 0
+        - openshift_master_root_volume_size is defined and openshift_master_root_volume_size | int > 0
+        - openshift_master_number_of_cpus is defined and openshift_master_number_of_cpus | int > 0
+        - openshift_master_memory_size is defined and openshift_master_memory_size | int > 0
+        - openshift_worker_root_volume_size is defined and openshift_worker_root_volume_size | int > 0
+        - openshift_worker_number_of_cpus is defined and openshift_worker_number_of_cpus | int > 0
+        - openshift_worker_memory_size is defined and openshift_worker_memory_size | int > 0
+        - openshift_release_url is defined and openshift_release_url | trim | length > 0
+        - openshift_rhcos_image_url is defined and openshift_rhcos_image_url | trim | length > 0
+
+    - name: check if the number of cluster workers is set properly (if applicable)
+      when: cluster_number_of_masters is undefined
+      ansible.builtin.assert:
+        that:
+          - 'cluster_number_of_workers is defined and cluster_number_of_workers | int > 0'
+
+    - name:  check if the number of cluster masters is set properly (if applicable)
+      when: cluster_number_of_masters is defined
+      ansible.builtin.assert:
+        that:
+          - 'cluster_number_of_masters | int == 1'
+          - 'cluster_number_of_workers | int == 0'
 
 - name: ensure KVM host is capable of fulfilling requested cluster configuration hardware demands
   block:
@@ -84,16 +98,16 @@
     - name: calculate cluster configuration hardware demands
       when: openshift_setup_dedicated_infra_nodes
       ansible.builtin.set_fact:
-        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers + openshift_infra_number_of_cpus * openshift_number_of_infra_nodes) / soundness_check_cpu_overcommit_factor }}'
-        total_memory_required: '{{ openshift_master_memory_size * 3 + openshift_worker_memory_size * cluster_number_of_workers + openshift_infra_memory_size * openshift_number_of_infra_nodes }}'
-        min_required_disk_space: '{{ (openshift_master_root_volume_size * 3 + openshift_worker_root_volume_size * cluster_number_of_workers + openshift_infra_root_volume_size * openshift_number_of_infra_nodes) / 5 }}'
+        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * (cluster_number_of_masters | default(3, true)) + openshift_worker_number_of_cpus * cluster_number_of_workers + openshift_infra_number_of_cpus * openshift_number_of_infra_nodes) / soundness_check_cpu_overcommit_factor }}'
+        total_memory_required: '{{ openshift_master_memory_size * (cluster_number_of_masters | default(3, true)) + openshift_worker_memory_size * cluster_number_of_workers + openshift_infra_memory_size * openshift_number_of_infra_nodes }}'
+        min_required_disk_space: '{{ (openshift_master_root_volume_size * (cluster_number_of_masters | default(3, true)) + openshift_worker_root_volume_size * cluster_number_of_workers + openshift_infra_root_volume_size * openshift_number_of_infra_nodes) / 5 }}'
 
     - name: calculate cluster configuration hardware demands
       when: not openshift_setup_dedicated_infra_nodes
       ansible.builtin.set_fact:
-        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * 3 + openshift_worker_number_of_cpus * cluster_number_of_workers) / soundness_check_cpu_overcommit_factor }}'
-        total_memory_required: '{{ openshift_master_memory_size * 3 + openshift_worker_memory_size * cluster_number_of_workers }}'
-        min_required_disk_space: '{{ (openshift_master_root_volume_size * 3 + openshift_worker_root_volume_size * cluster_number_of_workers) / 5 }}'
+        total_cpu_cores_required: '{{ (openshift_master_number_of_cpus * (cluster_number_of_masters | default(3, true)) + openshift_worker_number_of_cpus * cluster_number_of_workers) / soundness_check_cpu_overcommit_factor }}'
+        total_memory_required: '{{ openshift_master_memory_size * (cluster_number_of_masters | default(3, true)) + openshift_worker_memory_size * cluster_number_of_workers }}'
+        min_required_disk_space: '{{ (openshift_master_root_volume_size * (cluster_number_of_masters | default(3, true)) + openshift_worker_root_volume_size * cluster_number_of_workers) / 5 }}'
 
     - name: set current number of CPU cores detected
       when: ansible_architecture is inlist(['ppc64le', 'x86_64', 'aarch64'])

--- a/ansible/roles/tuning/tasks/k8s_configure_dfltcc.yml
+++ b/ansible/roles/tuning/tasks/k8s_configure_dfltcc.yml
@@ -78,7 +78,7 @@
 - name: configure 'dfltcc' kernel parameter for DFLT-enabled cluster worker nodes
   when:
     - dflt_enabled_worker_nodes.resources is defined
-    - (dflt_enabled_worker_nodes.resources | length) == cluster_number_of_workers
+    - (dflt_enabled_worker_nodes.resources | length) > 0
   block:
     - name: apply 'dfltcc' kernel parameter to cluster worker nodes
       kubernetes.core.k8s:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -83,3 +83,24 @@ all:
           ansible_become: true
     ...
 ```
+
+## Q: Which cluster topologies / layouts are supported by these playbooks? Can I install a single-node OpenShift (SNO) cluster as well?
+
+A: While the playbooks have been created with the standard multi-node cluster layout in mind you do have the option to install cluster with different layouts and sizes:
+
+| master nodes | worker nodes | cluster layout |
+|---------|----------|---------|
+| 3 | 1 to n | multi-node cluster |
+| 1 | 0 | single-node cluster |
+
+The following parameters in the `ansible/host_vars/host.yml.template` file are used to configure the topology of the OpenShift cluster and the sizes of the different cluster nodes:
+
+- openshift_master_root_volume_size
+- openshift_master_number_of_cpus
+- openshift_master_memory_size
+- cluster_number_of_workers
+- openshift_worker_root_volume_size
+- openshift_worker_number_of_cpus
+- openshift_worker_memory_size
+
+Please note that there is a special configuration parameter `cluster_number_of_masters` *not* present in the `host.yml.template` which determines how many cluster master nodes are to be installed. It is not listed along with the other aforementioned parameters as it basically determines the *general* cluster installation topology - single-node vs. multi-node. Setting this parameter to anything else than '1' is not supported at the moment - if this parameter is not defined at all then the number of master nodes to be installed defaults to '3'. Also make sure that whenever you do set the `cluster_number_of_masters` on purpose in your host-specific configuration YAML file that you set the corresponding parameter `cluster_number_of_workers` to '0'.


### PR DESCRIPTION
## Related issue(s)

Resolves #116

## Description

This PR adds support for single-node OpenShift (SNO) cluster installations.

Provide a concise description of the changes you want to merge with this pull request.

## DCO Sign-off
