### PR TITLE
Implemented host-specific post-boot hook

### DIFF
--- a/ansible/host_files/README.md
+++ b/ansible/host_files/README.md
@@ -1,8 +1,15 @@
 # The purpose of this directory
 
-This directory is used to store *advanced* cluster configuration files that are of importance to the OpenShift cluster installation process.
+This directory is used to store auxiliary files that are of importance to the OpenShift cluster installation process:
 
-These cluster configuration files are:
+- *advanced* cluster configuration files
+- user-provided Ansible playbooks
+
+The `.gitignore` file in this directory will ensure that whatever you place in here will not be persisted in git.
+
+## Advanced cluster configuration files
+
+The OpenShift cluster installation process supports the inclusion of *advanced* cluster configuration files. These files are:
 
 - `cluster-network-03-config.yml` - OpenShift cluster network configuration file (see: <https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal/installing-bare-metal-network-customizations.html>)
 
@@ -21,4 +28,37 @@ For example:
 ...
 ```
 
-The `.gitignore` file in this directory will ensure that whatever you place in here will not be persisted in git.
+## User-provided Ansible playbooks
+
+- `post_boot_tasks.yml` - a simple Ansible playbook containing one or more tasks to do whatever is needed for a given target host as part of a post-boot customization process
+
+The user-provided Ansible playbooks **must** be organized by KVM hosts, meaning that for every KVM host a specific post-boot customization process should be applied to a dedicated subdirectory must exist within this directory.
+
+For example:
+
+```bash
+/ansible
+...
+├── host_files
+│   ├── <my_kvm_host_name_1>
+│   │   └── post_boot_tasks.yml
+│   └── <my_kvm_host_name_2>
+│       └── post_boot_tasks.yml
+...
+```
+
+The Ansible playbook provided by the user should contain only simple tasks (e.g. `ansible.builtin.shell` or `ansible.builtin.command`). If any of the tasks contained in the user-provided playbook fails the entire playbook run (e.g. `setup_host.yml`) will fail.
+
+Here's an example of a simple `post_boot_tasks.yml` playbook for an IBM zSystems / LinuxONE target host that activates a DASD disk and mounts the filesystem contained on that disk accordingly:
+
+```yaml
+---
+
+- name: attach DASD disks to host
+  ansible.builtin.shell: |
+    cio_ignore -r 0.0.{{ item.disk_id }}
+    chccwdev -e 0.0.{{ item.disk_id }}
+    mount {{ item.device_id }} {{ item.mount_point }}
+  loop:
+    - { 'disk_id': 'b7a0', 'device_id': '/dev/dasdb1', 'mount_point': '/var/lib/libvirt/openshift-images' }
+```

--- a/ansible/reboot_host.yml
+++ b/ansible/reboot_host.yml
@@ -5,3 +5,17 @@
   tasks:
     - name: reboot host
       ansible.builtin.include_tasks: '{{ inventory_dir }}/tasks/reboot_host.yml'
+
+    - name: run post-boot host customizations
+      vars:
+        post_boot_tasks_file: '{{ inventory_dir }}/host_files/{{ inventory_hostname }}/post_boot_tasks.yml'
+      block:
+        - name: check if host-specific post-boot customizations file exists
+          ansible.builtin.stat:
+            path: '{{ post_boot_tasks_file }}'
+          register: post_boot_tasks_file_info
+          delegate_to: localhost
+
+        - name: run post-boot customization tasks
+          when: post_boot_tasks_file_info.stat.exists
+          ansible.builtin.include_tasks: '{{ post_boot_tasks_file }}'


### PR DESCRIPTION
## Related issue(s)

Resolves #118 

## Description

This PR implements a way for the playbook user to include host-specific post-boot customization Ansible tasks without having to modify the source of any of the existing playbooks.

## DCO Sign-off

Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>
