### PR TITLE
Added Fedora 37 host OS support, add libvirt-nss support

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -867,6 +867,158 @@ os_packages:
       - httpd
       - fio
       - bash-completion
+  '37_0':
+    groups:
+      - '@RPM Development Tools'
+      - '@Development Tools'
+    modules:
+      # mimics @virt:rhel/common
+      - hivex
+      - hivex-devel
+      - libguestfs
+      - libguestfs-appliance
+      - libguestfs-bash-completion
+      - libguestfs-devel
+      - libguestfs-gfs2
+      - libguestfs-gobject
+      - libguestfs-gobject-devel
+      - libguestfs-rescue
+      - libguestfs-rsync
+      - libguestfs-xfs
+      - libiscsi
+      - libiscsi-devel
+      - libiscsi-utils
+      - libnbd
+      - libnbd-bash-completion
+      - libnbd-devel
+      - libtpms
+      - libtpms-devel
+      - libvirt
+      - libvirt-client
+      - libvirt-daemon
+      - libvirt-daemon-config-network
+      - libvirt-daemon-config-nwfilter
+      - libvirt-daemon-driver-interface
+      - libvirt-daemon-driver-network
+      - libvirt-daemon-driver-nodedev
+      - libvirt-daemon-driver-nwfilter
+      - libvirt-daemon-driver-qemu
+      - libvirt-daemon-driver-secret
+      - libvirt-daemon-driver-storage
+      - libvirt-daemon-driver-storage-core
+      - libvirt-daemon-driver-storage-disk
+      - libvirt-daemon-driver-storage-iscsi
+      - libvirt-daemon-driver-storage-logical
+      - libvirt-daemon-driver-storage-mpath
+      - libvirt-daemon-driver-storage-rbd
+      - libvirt-daemon-driver-storage-scsi
+      - libvirt-daemon-kvm
+      - libvirt-dbus
+      - libvirt-devel
+      - libvirt-docs
+      - libvirt-libs
+      - libvirt-lock-sanlock
+      - libvirt-nss
+      - libvirt-wireshark
+      - lua-guestfs
+      - nbdfuse
+      - nbdkit
+      - nbdkit-bash-completion
+      - nbdkit-basic-filters
+      - nbdkit-basic-plugins
+      - nbdkit-curl-plugin
+      - nbdkit-devel
+      - nbdkit-example-plugins
+      - nbdkit-gzip-filter
+      - nbdkit-linuxdisk-plugin
+      - nbdkit-nbd-plugin
+      - nbdkit-python-plugin
+      - nbdkit-server
+      - nbdkit-ssh-plugin
+      - nbdkit-tar-filter
+      - nbdkit-tmpdisk-plugin
+      - nbdkit-xz-filter
+      - perl-Sys-Guestfs
+      - perl-Sys-Virt
+      - perl-hivex
+      - python3-hivex
+      - python3-libguestfs
+      - python3-libnbd
+      - python3-libvirt
+      - qemu-guest-agent
+      - qemu-img
+      - qemu-kvm
+      - qemu-kvm-core
+      - ruby-hivex
+      - ruby-libguestfs
+      - supermin
+      - supermin-devel
+      - swtpm
+      - swtpm-libs
+      - swtpm-tools
+      - virt-dib
+      # mimics @rust-toolset:rhel8/common
+      - cargo
+      - cargo-doc
+      - clippy
+      - rls
+      - rust
+      - rust-analysis
+      - rust-doc
+      - rust-gdb
+      - rust-lldb
+      - rust-src
+      - rust-std-static
+      - rustfmt
+    rpms:
+      - bind-utils
+      - iputils
+      - podman
+      - tmux
+      - wget
+      - curl
+      - vim-enhanced
+      - rsync
+      - genisoimage
+      - qemu-img
+      - qemu-kvm
+      - libvirt
+      - libvirt-daemon-config-network
+      - libvirt-daemon-kvm
+      - libvirt-client
+      - virt-install
+      - virt-manager
+      - libguestfs-tools-c
+      - openssl
+      - openssl-devel
+      - libffi
+      - libffi-devel
+      - policycoreutils-python-utils
+      - python3-jmespath
+      - python3-jsonpatch
+      - python3-pyyaml
+      - python3-pip
+      - python3-devel
+      - python3-netaddr
+      - python3-policycoreutils
+      - python3-setuptools
+      - python3-lxml
+      - python3-firewall
+      - python3-libvirt
+      - python3-libselinux
+      - python3-libsemanage
+      - python3-wheel
+      - ipmitool
+      - gcc
+      - gcc-c++
+      - git-lfs
+      - clang
+      - jq
+      - lsof
+      - net-tools
+      - httpd
+      - fio
+      - bash-completion
 
 # Python-related software packages
 python_packages:
@@ -927,6 +1079,14 @@ python_packages:
       - virtualenv==20.16.5
       - xmltodict==0.13.0
   '36_0':
+    essential:
+      - pip==22.2.2
+      - setuptools-rust==1.5.1
+    required:
+      - openshift==0.13.1
+      - virtualenv==20.16.5
+      - xmltodict==0.13.0
+  '37_0':
     essential:
       - pip==22.2.2
       - setuptools-rust==1.5.1

--- a/ansible/roles/basics/meta/main.yml
+++ b/ansible/roles/basics/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/common/meta/main.yml
+++ b/ansible/roles/common/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/crypto/meta/main.yml
+++ b/ansible/roles/crypto/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/firewall/meta/main.yml
+++ b/ansible/roles/firewall/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/libvirt/meta/main.yml
+++ b/ansible/roles/libvirt/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/libvirt/tasks/main.yml
+++ b/ansible/roles/libvirt/tasks/main.yml
@@ -1,5 +1,36 @@
 ---
 
+- name: install and enable libvirt-nss
+  block:
+    - name: ensure libvirt-nss package is present
+      ansible.builtin.dnf:
+        name: libvirt-nss
+        state: present
+
+    - name: enable libvirt-nss module (RHEL only)
+      when: "ansible_distribution == 'RedHat'"
+      block:
+        - name: add libvirt-nss module to /etc/nsswitch.conf
+          ansible.builtin.replace:
+            path: /etc/authselect/user-nsswitch.conf
+            regexp: '^hosts:.*'
+            replace: 'hosts: files libvirt dns myhostname'
+            backup: true
+
+        - name: activate change
+          ansible.builtin.command:
+            cmd: 'authselect apply-changes'
+
+    - name: enable libvirt-nss module (Fedora only)
+      when: "ansible_distribution == 'Fedora'"
+      block:
+        - name: add libvirt-nss module to /etc/nsswitch.conf
+          ansible.builtin.replace:
+            path: /etc/nsswitch.conf
+            regexp: '^hosts:.*'
+            replace: 'hosts: files libvirt myhostname resolve [!UNAVAIL=return] dns'
+            backup: true
+
 - name: enable IPv4 forwarding
   ansible.posix.sysctl:
     name: '{{ item }}'

--- a/ansible/roles/networking/meta/main.yml
+++ b/ansible/roles/networking/meta/main.yml
@@ -12,6 +12,11 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"
 
 dependencies:
   - role: common

--- a/ansible/roles/ocp_build_installer/meta/main.yml
+++ b/ansible/roles/ocp_build_installer/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/ocp_cleanup/meta/main.yml
+++ b/ansible/roles/ocp_cleanup/meta/main.yml
@@ -12,6 +12,11 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"
 
 dependencies:
   - role: common

--- a/ansible/roles/ocp_install_clients/meta/main.yml
+++ b/ansible/roles/ocp_install_clients/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/ocp_install_cluster/meta/main.yml
+++ b/ansible/roles/ocp_install_cluster/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/ocp_install_cluster_wrapup/meta/main.yml
+++ b/ansible/roles/ocp_install_cluster_wrapup/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/ocp_prepare_install/meta/main.yml
+++ b/ansible/roles/ocp_prepare_install/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/ocp_provision_nodes/meta/main.yml
+++ b/ansible/roles/ocp_provision_nodes/meta/main.yml
@@ -12,6 +12,11 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"
 
 dependencies:
   - role: common

--- a/ansible/roles/selinux/meta/main.yml
+++ b/ansible/roles/selinux/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/soundness_check/meta/main.yml
+++ b/ansible/roles/soundness_check/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/soundness_check/tasks/main.yml
+++ b/ansible/roles/soundness_check/tasks/main.yml
@@ -30,10 +30,10 @@
     - name: check Fedora prerequisites
       when: "ansible_distribution == 'Fedora'"
       block:
-        - name: ensure that the major Fedora version is 35 or 36
+        - name: ensure that the major Fedora version is 35, 36 or 37
           ansible.builtin.assert:
             that:
-              - '{{ ansible_distribution_major_version is inlist(["35", "36"]) }}'
+              - '{{ ansible_distribution_major_version is inlist(["35", "36", "37"]) }}'
 
 - name: ensure the targeted KVM host architecture is supported by KVM (RHEL only)
   when: "ansible_distribution == 'RedHat'"

--- a/ansible/roles/tuning/meta/main.yml
+++ b/ansible/roles/tuning/meta/main.yml
@@ -12,3 +12,8 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"

--- a/ansible/roles/vbmc/meta/main.yml
+++ b/ansible/roles/vbmc/meta/main.yml
@@ -12,6 +12,11 @@ galaxy_info:
       versions:
         - "8"
         - "9"
+    - name: Fedora
+      versions:
+        - "35"
+        - "36"
+        - "37"
 
 dependencies:
   - role: common

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -20,8 +20,9 @@ In order to run the Ansible playbooks in this repository you need:
     - RHEL 9.1 (with an **active** Red Hat subscription)
     - Fedora 35
     - Fedora 36
+    - Fedora 37
   - using one of the following hardware architectures:
-    - s390x (an IBM zSystems / LinuxONE LPAR, supported: z13 / z14 / z15 / z16)
+    - s390x (an IBM zSystems / LinuxONE LPAR, supported: z14 / z15 / z16)
     - ppc64le (an IBM Power Systems bare metal host or LPAR, supported: POWER9)
     - x86_64 (an Intel- or AMD-based bare metal host)
     - aarch64 (an ARM64-based bare metal host)


### PR DESCRIPTION
## Related issue(s)

Resolves #128 

## Description

This PR adds Fedora 37 OS support for the target KVM host. It also adds support for libvirt-nss.

## DCO Sign-off
