### PR TITLE
Fixed libvirt-nss module configuration activation

### DIFF
--- a/ansible/roles/libvirt/tasks/main.yml
+++ b/ansible/roles/libvirt/tasks/main.yml
@@ -19,7 +19,7 @@
 
         - name: activate change
           ansible.builtin.command:
-            cmd: 'authselect apply-changes'
+            cmd: 'authselect apply-changes -b'
 
     - name: enable libvirt-nss module (Fedora only)
       when: "ansible_distribution == 'Fedora'"


### PR DESCRIPTION
## Related issue(s)

Resolves #130

## Description

This PR fixes the libvirt-nss module configuration issue for RHEL operating systems.