### PR TITLE
Made long-running tasks async, added timeout override options for clu…

### DIFF
--- a/ansible/roles/basics/tasks/install_terraform_providers.yml
+++ b/ansible/roles/basics/tasks/install_terraform_providers.yml
@@ -15,6 +15,8 @@
   environment:
     GOPATH: '{{ tfprovider_temp_dir.path }}/go'
     PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ tfprovider_temp_dir.path }}/go/bin'
+  async: 600
+  poll: 10
 
 - name: create global terraform plugin directory
   ansible.builtin.file:

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -198,6 +198,8 @@
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
         PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+      async: 600
+      poll: 10
 
     - name: remove existing terraform binary from /usr/local/bin
       ansible.builtin.file:
@@ -307,6 +309,8 @@
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
         PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+      async: 600
+      poll: 10
 
     - name: remove existing butane binary from /usr/local/bin
       ansible.builtin.file:
@@ -351,6 +355,8 @@
       environment:
         GOPATH: '{{ temp_dir.path }}/go'
         PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+      async: 600
+      poll: 10
 
     - name: remove existing ocm binary from /usr/local/bin
       ansible.builtin.file:

--- a/ansible/roles/ocp_build_installer/tasks/main.yml
+++ b/ansible/roles/ocp_build_installer/tasks/main.yml
@@ -73,6 +73,8 @@
         PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
         DEFAULT_ARCH: '{{ architecture_alias }}'
         BUILD_VERSION: '{{ openshift_installer_version }}'
+      async: 600
+      poll: 10
 
     - name: remove existing openshift-install binary from /usr/local/bin
       ansible.builtin.file:

--- a/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
+++ b/ansible/roles/ocp_build_installer/tasks/patch_installer.yml
@@ -25,3 +25,23 @@
     - not cluster_main_tf_file_info.stat.exists
     - cluster_network_mtu is defined
     - cluster_network_mtu
+
+- name: increase hard-coded timeouts
+  block:
+    - name: increase bootstrapping timeout # noqa no-tabs
+      when:
+        - cluster_bootstrap_timeout_override is defined
+        - cluster_bootstrap_timeout_override >= 30
+      ansible.builtin.lineinfile:
+        path: '{{ temp_dir.path }}/installer/cmd/openshift-install/create.go'
+        regexp: '^\ttimeout := 30.*'
+        line: "\ttimeout := {{ cluster_bootstrap_timeout_override }} * time.Minute"
+
+    - name: increase cluster initialization timeout # noqa no-tabs
+      when:
+        - cluster_init_timeout_override is defined
+        - cluster_init_timeout_override >= 40
+      ansible.builtin.lineinfile:
+        path: '{{ temp_dir.path }}/installer/cmd/openshift-install/create.go'
+        regexp: '^\ttimeout := 40.*'
+        line: "\ttimeout := {{ cluster_init_timeout_override }} * time.Minute"

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -43,6 +43,18 @@ ssh root@$$YOUR_KVM_HOST_NAME$$
 tail -fn +1 /root/ocp4-workdir/.openshift_install.log
 ```
 
+If you've deduced the timeouts to be caused by general slowness of the hardware your KVM host runs on (meaning: slow CPU speed, slow network connections, etc.) you can try to rerun the cluster installation with increased timeouts. The following timeouts defined by the OpenShift installer can be overridden:
+
+- cluster bootstrap timeout (usually defaults to 30 minutes)
+- cluster initialization timeout (usually defaults to 40 minutes)
+
+To override either of these timeouts run the `run_ocp_install.yml` playbook as follows:
+
+```bash
+cd ansible
+ansible-playbook run_ocp_install.yml -e cluster_bootstrap_timeout_override=60 -e cluster_init_timeout_override=120
+```
+
 ### Using an incompatible libvirt version
 
 The RHOCP cluster installation times out and you'll find this error message in the RHOCP cluster installation log file:
@@ -86,7 +98,7 @@ Afterwards run the following playbooks in this repository to reboot the KVM host
 ```bash
 cd ansible
 ansible-playbook reboot_host.yml
-ansible-playbook ansible-playbook cleanup_ocp_install.yml -e cleanup_ignore_errors=true
+ansible-playbook cleanup_ocp_install.yml -e cleanup_ignore_errors=true
 ```
 
 Please note that the playbooks do implement a safeguard mechanism to ensure that under normal circumstances this libvirt incompatibility issue will not manifest itself. However depending on your actual KVM host configuration there's still the off chance for this to happen, hence it being mentioned here.


### PR DESCRIPTION
…ster installation

## Related issue(s)

Resolves #139 

## Description

This PR addresses the occasional timeout of long-running tasks, specifically the ones doing code compilation. The PR also introduces an advanced feature that lets the use override to timeout values defined by the OpenShift installation process: cluster bootstrapping timeout and cluster initialization timeout.
