### PR TITLE
Use dedicated switch to install optional software packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,3 @@ Resolves #.
 ## Description
 
 Provide a concise description of the changes you want to merge with this pull request.
-
-## DCO Sign-off

--- a/ansible/roles/basics/tasks/main.yml
+++ b/ansible/roles/basics/tasks/main.yml
@@ -74,6 +74,9 @@
     - '{{ os_packages[os_version]["rpms"] }}'
 
 - name: install optional software packages
+  when:
+    - install_optional_sw is defined
+    - install_optional_sw
   block:
     - name: install packages applicable to all host architectures
       ansible.builtin.dnf:
@@ -83,12 +86,12 @@
         disable_gpg_check: true
 
     - name: install packages applicable to s390x hosts only
+      when: "ansible_architecture == 's390x'"
       ansible.builtin.dnf:
         name:
           - 'https://zhwmodel.s3.eu.cloud-object-storage.appdomain.cloud/zhwmodel-1.5-965b308.s390x.rpm'
         state: present
         disable_gpg_check: true
-      when: "ansible_architecture == 's390x'"
 
 - name: install prerequisite Python packages (from source)
   vars:
@@ -176,6 +179,9 @@
       when: temp_dir.path is defined
 
 - name: compile and install terraform
+  when:
+    - install_optional_sw is defined
+    - install_optional_sw
   block:
     - name: create temporary download directory
       ansible.builtin.tempfile:
@@ -222,6 +228,9 @@
       when: temp_dir.path is defined
 
 - name: compile and install various terraform providers
+  when:
+    - install_optional_sw is defined
+    - install_optional_sw
   block:
     - name: create temporary download directory
       ansible.builtin.tempfile:
@@ -246,6 +255,9 @@
       when: temp_dir.path is defined
 
 - name: install helm
+  when:
+    - install_optional_sw is defined
+    - install_optional_sw
   block:
     - name: create temporary download directory
       ansible.builtin.tempfile:
@@ -287,6 +299,9 @@
       when: temp_dir.path is defined
 
 - name: compile and install butane
+  when:
+    - install_optional_sw is defined
+    - install_optional_sw
   block:
     - name: create temporary download directory
       ansible.builtin.tempfile:
@@ -321,52 +336,6 @@
       ansible.builtin.copy:
         src: '{{ temp_dir.path }}/butane/bin/{{ architecture_alias }}/butane'
         dest: /usr/local/bin/butane
-        owner: root
-        group: root
-        mode: '0755'
-        remote_src: true
-  always:
-    - name: delete temporary download directory
-      ansible.builtin.file:
-        path: '{{ temp_dir.path }}'
-        state: absent
-      when: temp_dir.path is defined
-
-- name: compile and install ocm
-  block:
-    - name: create temporary download directory
-      ansible.builtin.tempfile:
-        state: directory
-        suffix: ocm
-      register: temp_dir
-
-    - name: fetch ocm source code
-      ansible.builtin.git:
-        repo: 'https://github.com/openshift-online/ocm-cli.git'
-        dest: '{{ temp_dir.path }}/ocm-cli'
-        version: 'v{{ ocm_version }}'
-        single_branch: true
-        depth: 1
-
-    - name: build ocm binary
-      ansible.builtin.command:
-        cmd: 'make all'
-        chdir: '{{ temp_dir.path }}/ocm-cli'
-      environment:
-        GOPATH: '{{ temp_dir.path }}/go'
-        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
-      async: 600
-      poll: 10
-
-    - name: remove existing ocm binary from /usr/local/bin
-      ansible.builtin.file:
-        path: /usr/local/bin/ocm
-        state: absent
-
-    - name: copy ocm binary to /usr/local/bin
-      ansible.builtin.copy:
-        src: '{{ temp_dir.path }}/ocm-cli/ocm'
-        dest: /usr/local/bin/ocm
         owner: root
         group: root
         mode: '0755'

--- a/ansible/roles/ocp_cleanup/tasks/archive_cluster_ocm.yml
+++ b/ansible/roles/ocp_cleanup/tasks/archive_cluster_ocm.yml
@@ -6,16 +6,55 @@
   register: ocm_api_token_file_info
   delegate_to: localhost
 
-- name: check if the ocm binary exists
-  ansible.builtin.stat:
-    path: /usr/local/bin/ocm
-  register: ocm_binary_info
+- name: compile and install ocm
+  when: ocm_api_token_file_info.stat.exists
+  block:
+    - name: create temporary download directory
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: ocm
+      register: temp_dir
+
+    - name: fetch ocm source code
+      ansible.builtin.git:
+        repo: 'https://github.com/openshift-online/ocm-cli.git'
+        dest: '{{ temp_dir.path }}/ocm-cli'
+        version: 'v{{ ocm_version }}'
+        single_branch: true
+        depth: 1
+
+    - name: build ocm binary
+      ansible.builtin.command:
+        cmd: 'make all'
+        chdir: '{{ temp_dir.path }}/ocm-cli'
+      environment:
+        GOPATH: '{{ temp_dir.path }}/go'
+        PATH: '{{ ansible_env.PATH }}:/usr/local/go/bin:{{ temp_dir.path }}/go/bin'
+      async: 600
+      poll: 10
+
+    - name: remove existing ocm binary from /usr/local/bin
+      ansible.builtin.file:
+        path: /usr/local/bin/ocm
+        state: absent
+
+    - name: copy ocm binary to /usr/local/bin
+      ansible.builtin.copy:
+        src: '{{ temp_dir.path }}/ocm-cli/ocm'
+        dest: /usr/local/bin/ocm
+        owner: root
+        group: root
+        mode: '0755'
+        remote_src: true
+  always:
+    - name: delete temporary download directory
+      ansible.builtin.file:
+        path: '{{ temp_dir.path }}'
+        state: absent
+      when: temp_dir.path is defined
 
 - name: archive the cluster in OCM
-  when:
-    - ocm_api_token_file_info.stat.exists
-    - ocm_binary_info.stat.exists
-    - ocm_binary_info.stat.executable
+  when: ocm_api_token_file_info.stat.exists
   block:
     - name: login to OCM
       ansible.builtin.command:


### PR DESCRIPTION
## Related issue(s)

Resolves #141

## Description

This PR addresses the aforementioned issue by introducing a new playbook option that allows for installation of optional third-party packages / binaries like tcping, zhwmodel, terraform etc. which are not needed for the OpenShift installation itself but could come in handy at a later time. The new option is called `install_optional_sw` and must be specified for playbook execution like this: `ansible-playbook setup_host.yml -e install_optional_sw=true`. The default is *not* to install optional packages.

