### PR TITLE
Added DCO signoff

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
 
 # third-party software versions
-go_version: 1.18.7
-terraform_version: 1.3.7
-terraform_ibm_provider_version: 1.49.0
+go_version: 1.19.11
+terraform_version: 1.3.9
+terraform_ibm_provider_version: 1.50.0
 terraform_libvirt_provider_version: 0.7.1
-helm_version: 3.9.4
-butane_version: 0.15.0
-ocm_version: 0.1.64
-yq_version: 4.27.2
+helm_version: 3.12.2
+butane_version: 0.18.0
+ocm_version: 0.1.67
+yq_version: 4.34.2
 
 # OS-related software modules
 os_packages:
@@ -244,6 +244,64 @@ os_packages:
       - httpd
       - fio
       - bash-completion
+  '8_8':
+    groups:
+      - '@RPM Development Tools'
+      - '@Development Tools'
+    modules:
+      - '@virt:rhel/common'
+      - '@rust-toolset:rhel8/common'
+    rpms:
+      - bind-utils
+      - iputils
+      - podman
+      - tmux
+      - wget
+      - curl
+      - vim-enhanced
+      - rsync
+      - genisoimage
+      - qemu-img
+      - qemu-kvm
+      - libvirt
+      - libvirt-daemon-config-network
+      - libvirt-daemon-kvm
+      - libvirt-client
+      - libvirt-devel
+      - virt-install
+      - virt-manager
+      - libguestfs-tools-c
+      - openssl
+      - openssl-devel
+      - libffi
+      - libffi-devel
+      - policycoreutils-python-utils
+      - python3-jmespath
+      - python3-jsonpatch
+      - python3-pyyaml
+      - python3-pip
+      - python3-devel
+      - python3-netaddr
+      - python3-policycoreutils
+      - python3-wheel
+      - python3-setuptools
+      - python3-lxml
+      - python3-pyOpenSSL
+      - python3-firewall
+      - python3-libvirt
+      - python3-libselinux
+      - python3-libsemanage
+      - ipmitool
+      - gcc
+      - gcc-c++
+      - git-lfs
+      - clang
+      - jq
+      - lsof
+      - net-tools
+      - httpd
+      - fio
+      - bash-completion
   '9_0':
     groups:
       - '@RPM Development Tools'
@@ -343,7 +401,6 @@ os_packages:
       - cargo
       - cargo-doc
       - clippy
-      - rls
       - rust
       - rust-analysis
       - rust-doc
@@ -501,7 +558,163 @@ os_packages:
       - cargo
       - cargo-doc
       - clippy
-      - rls
+      - rust
+      - rust-analysis
+      - rust-doc
+      - rust-gdb
+      - rust-lldb
+      - rust-src
+      - rust-std-static
+      - rust-toolset
+      - rustfmt
+    rpms:
+      - bind-utils
+      - iputils
+      - podman
+      - tmux
+      - wget
+      - curl
+      - vim-enhanced
+      - rsync
+      - genisoimage
+      - qemu-img
+      - qemu-kvm
+      - libvirt
+      - libvirt-daemon-config-network
+      - libvirt-daemon-kvm
+      - libvirt-client
+      - virt-install
+      - virt-manager
+      - libguestfs-tools-c
+      - openssl
+      - openssl-devel
+      - libffi
+      - libffi-devel
+      - policycoreutils-python-utils
+      - python3-jmespath
+      - python3-jsonpatch
+      - python3-pyyaml
+      - python3-pip
+      - python3-devel
+      - python3-netaddr
+      - python3-policycoreutils
+      - python3-setuptools
+      - python3-lxml
+      - python3-firewall
+      - python3-libvirt
+      - python3-libselinux
+      - python3-libsemanage
+      - python3-wheel
+      - ipmitool
+      - gcc
+      - gcc-c++
+      - git-lfs
+      - clang
+      - jq
+      - lsof
+      - net-tools
+      - httpd
+      - fio
+      - bash-completion
+  '9_2':
+    groups:
+      - '@RPM Development Tools'
+      - '@Development Tools'
+    modules:
+      # mimics @virt:rhel/common
+      - hivex
+      - hivex-devel
+      - libguestfs
+      - libguestfs-appliance
+      - libguestfs-bash-completion
+      - libguestfs-devel
+      - libguestfs-gobject
+      - libguestfs-gobject-devel
+      - libguestfs-inspect-icons
+      - libguestfs-man-pages-ja
+      - libguestfs-man-pages-uk
+      - libguestfs-rescue
+      - libguestfs-rsync
+      - libguestfs-tools
+      - libguestfs-tools-c
+      - libguestfs-winsupport
+      - libguestfs-xfs
+      - libiscsi
+      - libiscsi-devel
+      - libiscsi-utils
+      - libnbd
+      - libnbd-bash-completion
+      - libnbd-devel
+      - libtpms
+      - libvirt
+      - libvirt-client
+      - libvirt-daemon
+      - libvirt-daemon-config-network
+      - libvirt-daemon-config-nwfilter
+      - libvirt-daemon-driver-interface
+      - libvirt-daemon-driver-network
+      - libvirt-daemon-driver-nodedev
+      - libvirt-daemon-driver-nwfilter
+      - libvirt-daemon-driver-qemu
+      - libvirt-daemon-driver-secret
+      - libvirt-daemon-driver-storage
+      - libvirt-daemon-driver-storage-core
+      - libvirt-daemon-driver-storage-disk
+      - libvirt-daemon-driver-storage-iscsi
+      - libvirt-daemon-driver-storage-logical
+      - libvirt-daemon-driver-storage-mpath
+      - libvirt-daemon-driver-storage-rbd
+      - libvirt-daemon-driver-storage-scsi
+      - libvirt-daemon-kvm
+      - libvirt-dbus
+      - libvirt-devel
+      - libvirt-docs
+      - libvirt-libs
+      - libvirt-lock-sanlock
+      - libvirt-nss
+      - lua-guestfs
+      - nbdfuse
+      - nbdkit
+      - nbdkit-bash-completion
+      - nbdkit-basic-filters
+      - nbdkit-basic-plugins
+      - nbdkit-curl-plugin
+      - nbdkit-devel
+      - nbdkit-example-plugins
+      - nbdkit-gzip-filter
+      - nbdkit-linuxdisk-plugin
+      - nbdkit-nbd-plugin
+      - nbdkit-python-plugin
+      - nbdkit-server
+      - nbdkit-ssh-plugin
+      - nbdkit-tar-filter
+      - nbdkit-tmpdisk-plugin
+      - nbdkit-xz-filter
+      - perl-Sys-Guestfs
+      - perl-hivex
+      - python3-hivex
+      - python3-libguestfs
+      - python3-libnbd
+      - python3-libvirt
+      - qemu-guest-agent
+      - qemu-img
+      - qemu-kvm
+      - qemu-kvm-block-curl
+      - qemu-kvm-block-rbd
+      - qemu-kvm-common
+      - qemu-kvm-core
+      - qemu-kvm-docs
+      - ruby-hivex
+      - ruby-libguestfs
+      - supermin
+      - supermin-devel
+      - swtpm
+      - swtpm-libs
+      - swtpm-tools
+      # mimics @rust-toolset:rhel8/common
+      - cargo
+      - cargo-doc
+      - clippy
       - rust
       - rust-analysis
       - rust-doc
@@ -652,12 +865,10 @@ os_packages:
       - swtpm
       - swtpm-libs
       - swtpm-tools
-      - virt-dib
       # mimics @rust-toolset:rhel8/common
       - cargo
       - cargo-doc
       - clippy
-      - rls
       - rust
       - rust-analysis
       - rust-doc
@@ -804,12 +1015,10 @@ os_packages:
       - swtpm
       - swtpm-libs
       - swtpm-tools
-      - virt-dib
       # mimics @rust-toolset:rhel8/common
       - cargo
       - cargo-doc
       - clippy
-      - rls
       - rust
       - rust-analysis
       - rust-doc
@@ -956,12 +1165,160 @@ os_packages:
       - swtpm
       - swtpm-libs
       - swtpm-tools
-      - virt-dib
       # mimics @rust-toolset:rhel8/common
       - cargo
       - cargo-doc
       - clippy
-      - rls
+      - rust
+      - rust-analysis
+      - rust-doc
+      - rust-gdb
+      - rust-lldb
+      - rust-src
+      - rust-std-static
+      - rustfmt
+    rpms:
+      - bind-utils
+      - iputils
+      - podman
+      - tmux
+      - wget
+      - curl
+      - vim-enhanced
+      - rsync
+      - genisoimage
+      - qemu-img
+      - qemu-kvm
+      - libvirt
+      - libvirt-daemon-config-network
+      - libvirt-daemon-kvm
+      - libvirt-client
+      - virt-install
+      - virt-manager
+      - libguestfs-tools-c
+      - openssl
+      - openssl-devel
+      - libffi
+      - libffi-devel
+      - policycoreutils-python-utils
+      - python3-jmespath
+      - python3-jsonpatch
+      - python3-pyyaml
+      - python3-pip
+      - python3-devel
+      - python3-netaddr
+      - python3-policycoreutils
+      - python3-setuptools
+      - python3-lxml
+      - python3-firewall
+      - python3-libvirt
+      - python3-libselinux
+      - python3-libsemanage
+      - python3-wheel
+      - ipmitool
+      - gcc
+      - gcc-c++
+      - git-lfs
+      - clang
+      - jq
+      - lsof
+      - net-tools
+      - httpd
+      - fio
+      - bash-completion
+  '38_0':
+    groups:
+      - '@RPM Development Tools'
+      - '@Development Tools'
+    modules:
+      # mimics @virt:rhel/common
+      - hivex
+      - hivex-devel
+      - libguestfs
+      - libguestfs-appliance
+      - libguestfs-bash-completion
+      - libguestfs-devel
+      - libguestfs-gfs2
+      - libguestfs-gobject
+      - libguestfs-gobject-devel
+      - libguestfs-rescue
+      - libguestfs-rsync
+      - libguestfs-xfs
+      - libiscsi
+      - libiscsi-devel
+      - libiscsi-utils
+      - libnbd
+      - libnbd-bash-completion
+      - libnbd-devel
+      - libtpms
+      - libtpms-devel
+      - libvirt
+      - libvirt-client
+      - libvirt-daemon
+      - libvirt-daemon-config-network
+      - libvirt-daemon-config-nwfilter
+      - libvirt-daemon-driver-interface
+      - libvirt-daemon-driver-network
+      - libvirt-daemon-driver-nodedev
+      - libvirt-daemon-driver-nwfilter
+      - libvirt-daemon-driver-qemu
+      - libvirt-daemon-driver-secret
+      - libvirt-daemon-driver-storage
+      - libvirt-daemon-driver-storage-core
+      - libvirt-daemon-driver-storage-disk
+      - libvirt-daemon-driver-storage-iscsi
+      - libvirt-daemon-driver-storage-logical
+      - libvirt-daemon-driver-storage-mpath
+      - libvirt-daemon-driver-storage-rbd
+      - libvirt-daemon-driver-storage-scsi
+      - libvirt-daemon-kvm
+      - libvirt-dbus
+      - libvirt-devel
+      - libvirt-docs
+      - libvirt-libs
+      - libvirt-lock-sanlock
+      - libvirt-nss
+      - libvirt-wireshark
+      - lua-guestfs
+      - nbdfuse
+      - nbdkit
+      - nbdkit-bash-completion
+      - nbdkit-basic-filters
+      - nbdkit-basic-plugins
+      - nbdkit-curl-plugin
+      - nbdkit-devel
+      - nbdkit-example-plugins
+      - nbdkit-gzip-filter
+      - nbdkit-linuxdisk-plugin
+      - nbdkit-nbd-plugin
+      - nbdkit-python-plugin
+      - nbdkit-server
+      - nbdkit-ssh-plugin
+      - nbdkit-tar-filter
+      - nbdkit-tmpdisk-plugin
+      - nbdkit-xz-filter
+      - perl-Sys-Guestfs
+      - perl-Sys-Virt
+      - perl-hivex
+      - python3-hivex
+      - python3-libguestfs
+      - python3-libnbd
+      - python3-libvirt
+      - qemu-guest-agent
+      - qemu-img
+      - qemu-kvm
+      - qemu-kvm-core
+      - ruby-hivex
+      - ruby-libguestfs
+      - supermin
+      - supermin-devel
+      - swtpm
+      - swtpm-libs
+      - swtpm-tools
+      # mimics @rust-toolset:rhel8/common
+      - cargo
+      - cargo-doc
+      - clippy
       - rust
       - rust-analysis
       - rust-doc
@@ -1054,6 +1411,14 @@ python_packages:
       - openshift==0.13.1
       - virtualenv==20.16.5
       - xmltodict==0.13.0
+  '8_8':
+    essential:
+      - pip==21.3.1
+      - setuptools-rust==1.1.2
+    required:
+      - openshift==0.13.1
+      - virtualenv==20.16.5
+      - xmltodict==0.13.0
   '9_0':
     essential:
       - pip==22.2.2
@@ -1063,6 +1428,14 @@ python_packages:
       - virtualenv==20.16.5
       - xmltodict==0.13.0
   '9_1':
+    essential:
+      - pip==22.2.2
+      - setuptools-rust==1.5.1
+    required:
+      - openshift==0.13.1
+      - virtualenv==20.16.5
+      - xmltodict==0.13.0
+  '9_2':
     essential:
       - pip==22.2.2
       - setuptools-rust==1.5.1
@@ -1087,6 +1460,14 @@ python_packages:
       - virtualenv==20.16.5
       - xmltodict==0.13.0
   '37_0':
+    essential:
+      - pip==22.2.2
+      - setuptools-rust==1.5.1
+    required:
+      - openshift==0.13.1
+      - virtualenv==20.16.5
+      - xmltodict==0.13.0
+  '38_0':
     essential:
       - pip==22.2.2
       - setuptools-rust==1.5.1

--- a/ansible/roles/soundness_check/tasks/main.yml
+++ b/ansible/roles/soundness_check/tasks/main.yml
@@ -15,25 +15,25 @@
             that:
               - '{{ ansible_distribution_major_version is inlist(["8", "9"]) }}'
 
-        - name: ensure that the minor version for RHEL 8 is 4, 5, 6 or 7
+        - name: ensure that the minor version for RHEL 8 is 4, 5, 6, 7 or 8
           when: "ansible_distribution_major_version == '8'"
           ansible.builtin.assert:
             that:
-              - '{{ (ansible_distribution_version | parse_version)["minor"] | string is inlist(["4", "5", "6", "7"]) }}'
+              - '{{ (ansible_distribution_version | parse_version)["minor"] | string is inlist(["4", "5", "6", "7", "8"]) }}'
 
-        - name: ensure that the minor version for RHEL 9 is 0 or 1
+        - name: ensure that the minor version for RHEL 9 is 0, 1 or 2
           when: "ansible_distribution_major_version == '9'"
           ansible.builtin.assert:
             that:
-              - '{{ (ansible_distribution_version | parse_version)["minor"] | string is inlist(["0", "1"]) }}'
+              - '{{ (ansible_distribution_version | parse_version)["minor"] | string is inlist(["0", "1", "2"]) }}'
 
     - name: check Fedora prerequisites
       when: "ansible_distribution == 'Fedora'"
       block:
-        - name: ensure that the major Fedora version is 35, 36 or 37
+        - name: ensure that the major Fedora version is 35, 36, 37 or 38
           ansible.builtin.assert:
             that:
-              - '{{ ansible_distribution_major_version is inlist(["35", "36", "37"]) }}'
+              - '{{ ansible_distribution_major_version is inlist(["35", "36", "37", "38"]) }}'
 
 - name: ensure the targeted KVM host architecture is supported by KVM (RHEL only)
   when: "ansible_distribution == 'RedHat'"

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -16,11 +16,14 @@ In order to run the Ansible playbooks in this repository you need:
     - RHEL 8.5 (with an **active** Red Hat subscription)
     - RHEL 8.6 (with an **active** Red Hat subscription)
     - RHEL 8.7 (with an **active** Red Hat subscription)
+    - RHEL 8.8 (with an **active** Red Hat subscription)
     - RHEL 9.0 (with an **active** Red Hat subscription)
     - RHEL 9.1 (with an **active** Red Hat subscription)
+    - RHEL 9.2 (with an **active** Red Hat subscription)
     - Fedora 35
     - Fedora 36
     - Fedora 37
+    - Fedora 38
   - using one of the following hardware architectures:
     - s390x (an IBM Z / LinuxONE LPAR, supported: z14 / z15 / z16)
     - ppc64le (an IBM Power Systems bare metal host or LPAR, supported: POWER9)


### PR DESCRIPTION
## Related issue(s)

Resolves #147 

## Description

This PR adds support for RHEL 8.8, RHEL 9.2 and Fedora 38 as KVM host OSes. Also the version of 3rd-party dependencies like go, yq etc. is bumped.
