### PR TITLE
Fix OCM error, bump go version

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -1,13 +1,12 @@
 ---
 
 # third-party software versions
-go_version: 1.19.11
+go_version: 1.20.3
 terraform_version: 1.3.9
 terraform_ibm_provider_version: 1.50.0
 terraform_libvirt_provider_version: 0.7.1
 helm_version: 3.12.2
 butane_version: 0.18.0
-ocm_version: 0.1.67
 yq_version: 4.34.2
 
 # OS-related software modules

--- a/ansible/roles/ocp_cleanup/defaults/main.yml
+++ b/ansible/roles/ocp_cleanup/defaults/main.yml
@@ -2,4 +2,5 @@
 
 cleanup_ignore_errors: false
 
+ocm_version: 0.1.67
 ocm_api_token_file: '{{ inventory_dir }}/secrets/.ocm_api_token'


### PR DESCRIPTION
## Related issue(s)

Resolves #152

## Description

This PR fixes the reported OCM error as well as bumps to installed go version in preparation for OCP 4.14.
