### PR TITLE
ODF 4.16 requires a minimum go version 1.21

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # third-party software versions
-go_version: 1.20.3
+go_version: 1.21.0
 terraform_version: 1.3.9
 terraform_ibm_provider_version: 1.50.0
 terraform_libvirt_provider_version: 0.7.1


### PR DESCRIPTION
## Related issue(s)

Resolves #.
ODF installation on KVM results in error on the go version.

## Description
```
TASK [ocp_build_installer : build openshift-install binary] ********************
fatal: [m13lp81]: FAILED! => changed=true 
  ansible_job_id: j561153045517.132308
  cmd:
  - hack/build.sh
  delta: '0:00:00.022213'
  end: '2024-07-23 15:48:23.786460'
  finished: 1
  msg: non-zero return code
  rc: 1
  results_file: /tmp/.ansible_async/j561153045517.132308
  start: '2024-07-23 15:48:23.764247'
  started: 1
  stderr: |-
    ++ dirname hack/build.sh
    + . hack/build-cluster-api.sh
    ++ set -e
    +++ go env GOOS
    +++ go env GOARCH
    ++ TARGET_OS_ARCH=linux_s390x
    ++ CLUSTER_API_BIN_DIR=/tmp/ansible.9_74xzt2ocpinst/installer/cluster-api/bin/linux_s390x
    ++ CLUSTER_API_MIRROR_DIR=/tmp/ansible.9_74xzt2ocpinst/installer/pkg/clusterapi/mirror/
    ++ ENVTEST_K8S_VERSION=1.29.5
    +++ go env GOOS
    +++ go env GOARCH
    ++ ENVTEST_ARCH=linux-s390x
    + minimum_go_version=1.21
    ++ go version
    ++ cut -d ' ' -f 3
    + current_go_version=go1.20.3
    ++ version 1.20.3
    ++ IFS=.
    ++ printf '%03d%03d%03d\n' 1 20 3
    ++ unset IFS
    ++ version 1.21
    ++ IFS=.
    ++ printf '%03d%03d%03d\n' 1 21
    ++ unset IFS
    + '[' 001020003 -lt 001021000 ']'
    + echo 'Go version should be greater or equal to 1.21'
    + exit 1
  stderr_lines: <omitted>
  stdout: Go version should be greater or equal to 1.21
  stdout_lines: <omitted>
 [started TASK: ocp_build_installer : delete temporary checkout directory on m13lp81]

TASK [ocp_build_installer : delete temporary checkout directory] ***************
changed: [m13lp81]

PLAY RECAP *********************************************************************
m13lp81                    : ok=110  changed=33   unreachable=0    failed=1    skipped=60   rescued=0    ignored=0   

Playbook run took 0 days, 0 hours, 3 minutes, 2 seconds
```