### PR TITLE
python3-wheel not available in the ODF 4.16 install with rhel 9.2

### DIFF
--- a/ansible/roles/basics/defaults/main.yml
+++ b/ansible/roles/basics/defaults/main.yml
@@ -760,7 +760,6 @@ os_packages:
       - python3-libvirt
       - python3-libselinux
       - python3-libsemanage
-      - python3-wheel
       - ipmitool
       - gcc
       - gcc-c++


### PR DESCRIPTION
## Related issue(s)

Resolves #.

## Description

The python3-wheel not available in the ODF 4.16 install with rhel 9.2


```
failed: [m13lp81] (item=['bind-utils', 'iputils', 'podman', 'tmux', 'wget', 'curl', 'vim-enhanced', 'rsync', 'genisoimage', 'qemu-img', 'qemu-kvm', 'libvirt', 'libvirt-daemon-config-network', 'libvirt-daemon-kvm', 'libvirt-client', 'virt-install', 'virt-manager', 'libguestfs-tools-c', 'openssl', 'openssl-devel', 'libffi', 'libffi-devel', 'policycoreutils-python-utils', 'python3-jmespath', 'python3-jsonpatch', 'python3-pyyaml', 'python3-pip', 'python3-devel', 'python3-netaddr', 'python3-policycoreutils', 'python3-setuptools', 'python3-lxml', 'python3-firewall', 'python3-libvirt', 'python3-libselinux', 'python3-libsemanage', 'python3-wheel', 'ipmitool', 'gcc', 'gcc-c++', 'git-lfs', 'clang', 'jq', 'lsof', 'net-tools', 'httpd', 'fio', 'bash-completion']) => changed=false 
  ansible_loop_var: item
  failures:
  - No package python3-wheel available.
```